### PR TITLE
change 'legendScroll' into 'legend'

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ require('./lib/chart/custom');
 
 require('./lib/component/graphic');
 require('./lib/component/grid');
-require('./lib/component/legendScroll');
+require('./lib/component/legend');
 require('./lib/component/tooltip');
 require('./lib/component/axisPointer');
 require('./lib/component/polar');


### PR DESCRIPTION
In the latest version of node-echarts, there are no 'legendScroll' in './lib/component' ,