### PR TITLE
fix bug #6969 色块脱离grid区域

### DIFF
--- a/src/chart/line/lineAnimationDiff.js
+++ b/src/chart/line/lineAnimationDiff.js
@@ -10,7 +10,7 @@ function sign(val) {
 function getStackedOnPoint(coordSys, data, idx) {
     var baseAxis = coordSys.getBaseAxis();
     var valueAxis = coordSys.getOtherAxis(baseAxis);
-    var valueStart = baseAxis.onZero
+    var valueStart = valueAxis.onZero
         ? 0 : valueAxis.scale.getExtent()[0];
 
     var valueDim = valueAxis.dim;

--- a/src/layout/barGrid.js
+++ b/src/layout/barGrid.js
@@ -236,7 +236,7 @@ function barLayoutGrid(seriesType, ecModel, api) {
 
         var barMinHeight = seriesModel.get('barMinHeight') || 0;
 
-        var valueAxisStart = baseAxis.onZero
+        var valueAxisStart = valueAxis.onZero
             ? valueAxis.toGlobalCoord(valueAxis.dataToCoord(0))
             : valueAxis.getGlobalExtent()[0];
 


### PR DESCRIPTION
cross x判断使用基轴，然而此处我认为应当使用各自的数值轴。
解决方法是使用valueaxis
修复前：
![befroe](https://user-images.githubusercontent.com/13759392/32871094-0fe5660e-caba-11e7-93e6-923fef212d87.png)

修复后：
![after](https://user-images.githubusercontent.com/13759392/32871100-17f8020c-caba-11e7-8ca6-eb6b3fc762df.png)

测试通过bar/bar2/bar3/bar-label-rotation/bar-large/line  