### PR TITLE
Fix #7855

### DIFF
--- a/src/component/tooltip/TooltipView.js
+++ b/src/component/tooltip/TooltipView.js
@@ -417,6 +417,10 @@ export default echarts.extendComponentView({
         var seriesIndex = el.seriesIndex;
         var seriesModel = ecModel.getSeriesByIndex(seriesIndex);
 
+        if (!el.dataModel && !seriesModel) {
+            return;
+        }
+
         // For example, graph link.
         var dataModel = el.dataModel || seriesModel;
         var dataIndex = el.dataIndex;


### PR DESCRIPTION
修复了在旭日图中，鼠标在返回上层按钮上悬浮时，tooltip 显示失败并抛出错误的问题。