### PR TITLE
geo label formatter不生效bug修复

### DIFF
--- a/src/coord/geo/GeoModel.js
+++ b/src/coord/geo/GeoModel.js
@@ -148,7 +148,9 @@ var GeoModel = ComponentModel.extend({
      */
     getFormattedLabel: function (name, status) {
         var regionModel = this.getRegionModel(name);
-        var formatter = regionModel.get('label.' + status + '.formatter');
+        // label参数结构更新
+        var path = status == 'normal' ? 'label.formatter' : 'label.' + status + '.formatter';
+        var formatter = regionModel.get(path);
         var params = {
             name: name
         };


### PR DESCRIPTION
跟了下源码发现是label配置项结构改动引起的
之前
`label: {
    normal: {
        formatter: ...
    }
}`
现在
`label: {
    formatter: ...
}`