### PR TITLE
Fix bug with combined Timeline & Visualmap use

### DIFF
--- a/src/component/visualMap/PiecewiseModel.js
+++ b/src/component/visualMap/PiecewiseModel.js
@@ -109,6 +109,11 @@ var PiecewiseModel = VisualMapModel.extend({
 
         resetMethods[this._mode].call(this);
 
+        // If the user has chosen selected options, do not reset them
+        if (!isInit && this.option.selected && newOption.selected === undefined) {
+            newOption.selected = this.option.selected
+        }
+
         this._resetSelected(newOption, isInit);
 
         var categories = this.option.categories;


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-echarts/issues/8655
in which chosen visualmap legend entries are reset when a graph is powered by a timeline