### PR TITLE
 Error in dataZoom when linking new series

### DIFF
--- a/src/component/dataZoom/DataZoomModel.js
+++ b/src/component/dataZoom/DataZoomModel.js
@@ -174,7 +174,7 @@ var DataZoomModel = echarts.extendComponentModel({
         var axisProxies = this._axisProxies;
 
         this.eachTargetAxis(function (dimNames, axisIndex, dataZoomModel, ecModel) {
-            var axisModel = this.dependentModels[dimNames.axis][axisIndex];
+            var axisModel = this.dependentModels[dimNames.axis][axisIndex] || dataZoomModel;
 
             // If exists, share axisProxy with other dataZoomModels.
             var axisProxy = axisModel.__dzAxisProxy || (


### PR DESCRIPTION
When a new series is added to the chart (for example by clicking some button), and the datazoom is linked to the existing series (adding a new index to xAxisIndex: [...]) , the _giveAxisProxies method is executed twice (Don't know why) and the first time it's executed "this.dependentModels[dimNames.axis][axisIndex]" at line 177 returns undefined, so "axisModel._dzAxisProxy" at line 180 throws an error. 
I don't know if this is the best way to solve it but it solved the problem for me.
