### PR TITLE
configurable MapOptions for BMap.Map constructor

### DIFF
--- a/extension/bmap/BMapCoordSys.js
+++ b/extension/bmap/BMapCoordSys.js
@@ -205,7 +205,7 @@ BMapCoordSys.create = function (ecModel, api) {
 
       bmapRoot.classList.add('ec-extension-bmap');
       root.appendChild(bmapRoot);
-      var bmap = bmapModel.__bmap = new BMap.Map(bmapRoot);
+      var bmap = bmapModel.__bmap = new BMap.Map(bmapRoot, bmapModel.get('mapOptions'));
       var overlay = new Overlay(viewportRoot);
       bmap.addOverlay(overlay); // Override
 


### PR DESCRIPTION
使 BMap.Map 构造函数中的 MapOptions 参数可配置。
此外，因为是和 echarts 结合使用，希望默认关闭底图可点功能 ( enableMapClick: false )。能解决一部分bug 比如: https://github.com/apache/incubator-echarts/issues/8422