### PR TITLE
Fix boxplot width calculation for non-category axes

### DIFF
--- a/src/chart/boxplot/boxplotLayout.js
+++ b/src/chart/boxplot/boxplotLayout.js
@@ -91,7 +91,7 @@ function calculateBase(groupItem) {
             maxDataCount = Math.max(maxDataCount, seriesModel.getData().count());
         });
         extent = baseAxis.getExtent(),
-        Math.abs(extent[1] - extent[0]) / maxDataCount;
+        bandWidth = Math.abs(extent[1] - extent[0]) / maxDataCount;
     }
 
     each(seriesModels, function (seriesModel) {


### PR DESCRIPTION
Currently, if the x-axis of a boxplot is not a category axis, then the width of the plot isn't set correctly.  This is because the expression to compute `bandWith` in this case isn't assigned to anything.  The fix is to actually assign the result of the expression to `bandWidth`, as it should be.  (See the diff for details.)