### PR TITLE
fix: #9011 gauge clockwise

### DIFF
--- a/src/chart/gauge/GaugeView.js
+++ b/src/chart/gauge/GaugeView.js
@@ -119,6 +119,9 @@ var GaugeView = ChartView.extend({
         }
 
         var getColor = function (percent) {
+            if (!clockwise) {
+                percent = 1 - percent
+            }
             // Less than 0
             if (percent <= 0) {
                 return colorList[0][1];


### PR DESCRIPTION
clockwise设置为false后，sector是逆时针渲染了，但是其它元素是顺时针渲染，且并没有逆时针渲染的选项
ps：for 滚成一团