### PR TITLE
axisLine.show option implemented for Gauge

### DIFF
--- a/src/chart/gauge/GaugeView.js
+++ b/src/chart/gauge/GaugeView.js
@@ -85,8 +85,9 @@ var GaugeView = ChartView.extend({
 
         var prevEndAngle = startAngle;
         var axisLineWidth = lineStyleModel.get('width');
-
-        for (var i = 0; i < colorList.length; i++) {
+        var showAxis = axisLineModel.get("show");
+        
+        for (var i = 0;showAxis && i < colorList.length; i++) {
             // Clamp
             var percent = Math.min(Math.max(colorList[i][0], 0), 1);
             var endAngle = startAngle + angleRangeSpan * percent;

--- a/src/chart/gauge/GaugeView.js
+++ b/src/chart/gauge/GaugeView.js
@@ -85,9 +85,9 @@ var GaugeView = ChartView.extend({
 
         var prevEndAngle = startAngle;
         var axisLineWidth = lineStyleModel.get('width');
-        var showAxis = axisLineModel.get("show");
+        var showAxis = axisLineModel.get('show');
         
-        for (var i = 0;showAxis && i < colorList.length; i++) {
+        for (var i = 0; showAxis && i < colorList.length; i++) {
             // Clamp
             var percent = Math.min(Math.max(colorList[i][0], 0), 1);
             var endAngle = startAngle + angleRangeSpan * percent;


### PR DESCRIPTION
As described in  #9194 - echarts ignores axisLine.show option. Support for this option added by this commit.