### PR TITLE
fix #9182 Graph    label.rotate is invalid

### DIFF
--- a/src/chart/graph/GraphView.js
+++ b/src/chart/graph/GraphView.js
@@ -200,7 +200,7 @@ export default echarts.extendChartView({
             && seriesModel.get('circular.rotateLabel');
         var cx = data.getLayout('cx');
         var cy = data.getLayout('cy');
-        var labelRotate = seriesModel.get('label.rotate') === undefined ? 0 : seriesModel.get('label.rotate');
+        var labelRotate = seriesModel.get('label.rotate') || 0;
         data.eachItemGraphicEl(function (el, idx) {
             var symbolPath = el.getSymbolPath();
             if (circularRotateLabel) {

--- a/src/chart/graph/GraphView.js
+++ b/src/chart/graph/GraphView.js
@@ -200,12 +200,9 @@ export default echarts.extendChartView({
             && seriesModel.get('circular.rotateLabel');
         var cx = data.getLayout('cx');
         var cy = data.getLayout('cy');
-        var labelRotate = seriesModel.get('label.rotate') || 0;
         data.eachItemGraphicEl(function (el, idx) {
-            var itemRotate = itemModel.get('label.rotate');
-            if (itemRotate != undefined) {
-                labelRotate = itemRotate;
-            }
+            var itemModel = data.getItemModel(idx);
+            var labelRotate = itemModel.get('label.rotate') || 0;
             var symbolPath = el.getSymbolPath();
             if (circularRotateLabel) {
                 var pos = data.getItemLayout(idx);

--- a/src/chart/graph/GraphView.js
+++ b/src/chart/graph/GraphView.js
@@ -200,6 +200,7 @@ export default echarts.extendChartView({
             && seriesModel.get('circular.rotateLabel');
         var cx = data.getLayout('cx');
         var cy = data.getLayout('cy');
+        var labelRotate = seriesModel.get('label.rotate') === undefined ? 0 : seriesModel.get('label.rotate');
         data.eachItemGraphicEl(function (el, idx) {
             var symbolPath = el.getSymbolPath();
             if (circularRotateLabel) {
@@ -222,7 +223,7 @@ export default echarts.extendChartView({
             }
             else {
                 symbolPath.setStyle({
-                    textRotation: 0
+                    textRotation: labelRotate *= Math.PI / 180
                 });
             }
         });

--- a/src/chart/graph/GraphView.js
+++ b/src/chart/graph/GraphView.js
@@ -202,6 +202,8 @@ export default echarts.extendChartView({
         var cy = data.getLayout('cy');
         var labelRotate = seriesModel.get('label.rotate') || 0;
         data.eachItemGraphicEl(function (el, idx) {
+            var itemModel = data.getItemModel(idx);
+            labelRotate = itemModel.get('label.rotate') || labelRotate;
             var symbolPath = el.getSymbolPath();
             if (circularRotateLabel) {
                 var pos = data.getItemLayout(idx);

--- a/src/chart/graph/GraphView.js
+++ b/src/chart/graph/GraphView.js
@@ -202,8 +202,10 @@ export default echarts.extendChartView({
         var cy = data.getLayout('cy');
         var labelRotate = seriesModel.get('label.rotate') || 0;
         data.eachItemGraphicEl(function (el, idx) {
-            var itemModel = data.getItemModel(idx);
-            labelRotate = itemModel.get('label.rotate') || labelRotate;
+            var itemRotate = itemModel.get('label.rotate');
+            if (itemRotate != undefined) {
+                labelRotate = itemRotate;
+            }
             var symbolPath = el.getSymbolPath();
             if (circularRotateLabel) {
                 var pos = data.getItemLayout(idx);


### PR DESCRIPTION
when `series[i].type` is `graph`, series[i].label.rotate is invalid
