### PR TITLE
fix: Update zrender to 4.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "rollup": "0.50.0",
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-uglify": "2.0.1",
-    "zrender": "4.0.6"
+    "zrender": "4.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepublish": "node build/build.js --prepublish"
   },
   "dependencies": {
-    "zrender": "4.0.5"
+    "zrender": "4.0.6"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.31",
@@ -35,6 +35,6 @@
     "rollup": "0.50.0",
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-uglify": "2.0.1",
-    "zrender": "4.0.5"
+    "zrender": "4.0.6"
   }
 }


### PR DESCRIPTION
zrender 4.0.5 causes a npm install error.
This version upgrade fixes https://github.com/apache/incubator-echarts/issues/9774