### PR TITLE
ci: add ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+
+node_js:
+  - "node"
+
+branches:
+  only:
+    - release
+    - master

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Please check its incubator status [here](http://incubator.apache.org/projects/ec
 
 **[中文官网](http://echarts.baidu.com)** | **[ENGLISH HOMEPAGE](https://echarts.apache.org/index.html)**
 
+[![Build Status](https://travis-ci.org/apache/incubator-echarts.svg?branch=master)](https://travis-ci.org/apache/incubator-echarts) [![](https://img.shields.io/npm/dw/echarts.svg?label=npm%20downloads&style=flat)](https://www.npmjs.com/package/echarts) ![Commits Since 4.0.0](https://img.shields.io/github/commits-since/apache/incubator-echarts/4.0.0.svg?colorB=%234c1&style=flat)
+
 ## Get ECharts
 
 You may choose one of the following methods:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "https://github.com/apache/incubator-echarts.git"
   },
   "scripts": {
-    "prepublish": "node build/build.js --prepublish"
+    "prepublish": "node build/build.js --prepublish",
+    "test": "node build/build.js"
   },
   "dependencies": {
     "zrender": "4.0.6"


### PR DESCRIPTION
ECharts CI status can be seen at https://travis-ci.org/apache/incubator-echarts.
Notice that Apache uses `.org` instead of `.com`.

See #9850 for more discussion on CI stuff.