### PR TITLE
Add option to hide duplicate axis labels

### DIFF
--- a/src/component/axis/AxisBuilder.js
+++ b/src/component/axis/AxisBuilder.js
@@ -636,6 +636,13 @@ function buildAxisLabel(axisBuilder, axisModel, opt) {
     var labelModel = axisModel.getModel('axisLabel');
     var labelMargin = labelModel.get('margin');
     var labels = axis.getViewLabels();
+    var hideDuplicates = retrieve(opt.axisLabelHideDuplicates, axisModel.get('axisLabel.hideDuplicates'));
+
+    if (hideDuplicates) {
+        labels = filter(labels, function (labelItem, index) {
+            return index === 0 || labels[index - 1].formattedLabel !== labelItem.formattedLabel;
+        });
+    }
 
     // Special label rotate.
     var labelRotation = (


### PR DESCRIPTION
- Adds a configurable option under `axisLabel` property to allow users to `hideDuplicates` (boolean)

Closes https://github.com/apache/incubator-echarts/issues/9896