### PR TITLE
Fix: calculate label bounding rect error when rich used

### DIFF
--- a/src/model/mixin/textStyle.js
+++ b/src/model/mixin/textStyle.js
@@ -56,6 +56,7 @@ export default {
             this.getShallow('align'),
             this.getShallow('verticalAlign') || this.getShallow('baseline'),
             this.getShallow('padding'),
+            this.getShallow('lineHeight'),
             this.getShallow('rich'),
             this.getShallow('truncateText')
         );

--- a/src/util/format.js
+++ b/src/util/format.js
@@ -236,4 +236,42 @@ export function capitalFirst(str) {
 
 export var truncateText = textContain.truncateText;
 
-export var getTextRect = textContain.getBoundingRect;
+/**
+ * @public
+ * @param {Object} opt
+ * @param {string} opt.text
+ * @param {string} opt.font
+ * @param {string} [opt.textAlign='left']
+ * @param {string} [opt.textVerticalAlign='top']
+ * @param {Array.<number>} [opt.textPadding]
+ * @param {number} [opt.textLineHeight]
+ * @param {Object} [opt.rich]
+ * @param {Object} [opt.truncate]
+ * @return {Object} {x, y, width, height, lineHeight}
+ */
+export function getTextBoundingRect(opt) {
+    return textContain.getBoundingRect(
+        opt.text,
+        opt.font,
+        opt.textAlign,
+        opt.textVerticalAlign,
+        opt.textPadding,
+        opt.textLineHeight,
+        opt.rich,
+        opt.truncate
+    );
+}
+
+/**
+ * @deprecated
+ * the `textLineHeight` was added later.
+ * For backward compatiblility, put it as the last parameter.
+ * But deprecated this interface. Please use `getTextBoundingRect` instead.
+ */
+export function getTextRect(
+    text, font, textAlign, textVerticalAlign, textPadding, rich, truncate, textLineHeight
+) {
+    return textContain.getBoundingRect(
+        text, font, textAlign, textVerticalAlign, textPadding, textLineHeight, rich, truncate
+    );
+}


### PR DESCRIPTION
Fix  calculate label bounding rect error when rich used 
(e.g., containLabel: true while axisLabel has rich)