### PR TITLE
Temporary solution for chart radar can display axisLabel correctly.

### DIFF
--- a/src/component/axis/AxisBuilder.js
+++ b/src/component/axis/AxisBuilder.js
@@ -643,7 +643,7 @@ function buildAxisLabel(axisBuilder, axisModel, opt) {
     ) * PI / 180;
 
     var labelLayout = innerTextLayout(opt.rotation, labelRotation, opt.labelDirection);
-    var rawCategoryData = axisModel.getCategories(true);
+    var rawCategoryData = axisModel.getCategories && axisModel.getCategories(true);
 
     var labelEls = [];
     var silent = isLabelSilent(axisModel);


### PR DESCRIPTION
* fix bug #9282


Add a defensive statement for `axisModel.getCategories`,  so axisLabel of chart radar can display correctly (cannot trigger event though, which isn't used widely).

It's a temporary solution until axisLabel of chart radar supported in the next release.