### PR TITLE
refactor(map): add segment ignore threshold in map draw

### DIFF
--- a/src/component/helper/MapDraw.js
+++ b/src/component/helper/MapDraw.js
@@ -214,6 +214,7 @@ MapDraw.prototype = {
                 || nameMap.set(region.name, new graphic.Group());
 
             var compoundPath = new graphic.CompoundPath({
+                segmentIgnoreThreshold: 1,
                 shape: {
                     paths: []
                 }
@@ -249,6 +250,7 @@ MapDraw.prototype = {
                     return;
                 }
                 compoundPath.shape.paths.push(new graphic.Polygon({
+                    segmentIgnoreThreshold: 1,
                     shape: {
                         points: geometry.exterior
                     }
@@ -256,6 +258,7 @@ MapDraw.prototype = {
 
                 for (var i = 0; i < (geometry.interiors ? geometry.interiors.length : 0); i++) {
                     compoundPath.shape.paths.push(new graphic.Polygon({
+                        segmentIgnoreThreshold: 1,
                         shape: {
                             points: geometry.interiors[i]
                         }


### PR DESCRIPTION
compoundPath and compoundPath.paths in  MapDraw.js set segmentIgnoreThreshold to 1 Manually, so the small segment will be ignored in map series to improve performance.  