### PR TITLE
feat: support backgroundColor for connected charts in toolbox

### DIFF
--- a/src/component/toolbox/feature/SaveAsImage.js
+++ b/src/component/toolbox/feature/SaveAsImage.js
@@ -36,6 +36,7 @@ SaveAsImage.defaultOption = {
     type: 'png',
     // Default use option.backgroundColor
     // backgroundColor: '#fff',
+    connectedBackgroundColor: '#fff',
     name: '',
     excludeComponents: ['toolbox'],
     pixelRatio: 1,
@@ -54,6 +55,7 @@ proto.onclick = function (ecModel, api) {
         type: type,
         backgroundColor: model.get('backgroundColor', true)
             || ecModel.get('backgroundColor') || '#fff',
+        connectedBackgroundColor: model.get('connectedBackgroundColor'),
         excludeComponents: model.get('excludeComponents'),
         pixelRatio: model.get('pixelRatio')
     });

--- a/src/echarts.js
+++ b/src/echarts.js
@@ -567,6 +567,21 @@ echartsProto.getConnectedDataURL = function (opts) {
         targetCanvas.height = height;
         var zr = zrender.init(targetCanvas);
 
+        // Background between the charts
+        if (opts.connectedBackgroundColor) {
+            zr.add(new graphic.Rect({
+                shape: {
+                    x: 0,
+                    y: 0,
+                    width: width,
+                    height: height
+                },
+                style: {
+                    fill: opts.connectedBackgroundColor
+                }
+            }));
+        }
+
         each(canvasList, function (item) {
             var img = new graphic.Image({
                 style: {

--- a/test/toolbox-saveImage-background.html
+++ b/test/toolbox-saveImage-background.html
@@ -1,0 +1,168 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script src="lib/esl.js"></script>
+    <script src="lib/config.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+    <style>
+        html,
+        body {
+            width: 80%;
+            height: 100%;
+            margin: 0;
+        }
+
+        #chart1, #chart2 {
+            background: #fff;
+            margin-bottom: 20px;
+            width: 80%;
+            height: 100%;
+        }
+    </style>
+
+    <p>The background of the exported png using toolbox should be yellow.</p>
+
+    <div id="chart1"></div>
+    <div id="chart2"></div>
+    <script>
+
+        require([
+            'echarts'
+            // 'echarts/chart/bar',
+            // 'echarts/component/polar',
+            // 'zrender/vml/vml'
+        ], function (echarts) {
+            var chart1 = echarts.init(document.getElementById('chart1'));
+            var chart2 = echarts.init(document.getElementById('chart2'));
+
+            var data1 = [];
+
+            var symbolCount = 6;
+
+            for (var i = 0; i < 100; i++) {
+                data1.push([
+                    Math.random() * 5,
+                    Math.random() * 4,
+                    Math.random() * 20,
+                    Math.round(Math.random() * (symbolCount - 1))
+                ]);
+            }
+
+            chart1.setOption({
+                backgroundColor: 'red',
+                "toolbox": {
+                    "feature": {
+                        "saveAsImage": {
+                            "show": true,
+                            "title": "Save as image",
+                            "type": "png",
+                            connectedBackgroundColor: 'yellow'
+                        },
+                        "dataZoom": {
+                            "yAxisIndex": "none",
+                            "show": true,
+                            "title": {
+                                "zoom": "Zoom in",
+                                "back": "Zoom out"
+                            },
+                        }
+                    },
+                    "show": true,
+                    "itemGap": 1,
+                    "top": 20,
+                    "right": 35
+                },
+                legend: {
+                    top: 50,
+                    data: ['scatter']
+                },
+                tooltip: {
+                    formatter: '{c}'
+                },
+                grid: {
+                    top: '26%',
+                    bottom: '26%'
+                },
+                xAxis: {
+                    type: 'value',
+                    splitLine: {
+                        show: false
+                    }
+                },
+                yAxis: {
+                    type: 'value',
+                    splitLine: {
+                        show: false
+                    }
+                },
+                series: [{
+                    name: 'scatter',
+                    type: 'scatter',
+                    symbolSize: 30,
+                    data: data1
+                }]
+            });
+
+            chart2.setOption({
+                backgroundColor: 'green',
+                legend: {
+                    top: 50,
+                    data: ['scatter']
+                },
+                tooltip: {
+                    formatter: '{c}'
+                },
+                grid: {
+                    top: '26%',
+                    bottom: '26%'
+                },
+                xAxis: {
+                    type: 'value',
+                    splitLine: {
+                        show: false
+                    }
+                },
+                yAxis: {
+                    type: 'value',
+                    splitLine: {
+                        show: false
+                    }
+                },
+                series: [{
+                    name: 'scatter',
+                    type: 'scatter',
+                    symbolSize: 30,
+                    data: data1
+                }]
+            });
+
+            echarts.connect([chart1, chart2]);
+
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
`toolbox.feature.saveAsImage.connectedBackgroundColor` can be used to set the background color.
Fix #10099.

Document changes are available at https://github.com/ecomfe/echarts-doc/commit/18983da9ab64a61bde69f13b63f1c729a93c2f98 , which should be merged after this PR is accepted.