### PR TITLE
Fix stack with datazoom, x axis is not correct (#10359)

### DIFF
--- a/src/component/dataZoom/AxisProxy.js
+++ b/src/component/dataZoom/AxisProxy.js
@@ -21,6 +21,7 @@ import * as zrUtil from 'zrender/src/core/util';
 import * as numberUtil from '../../util/number';
 import * as helper from './helper';
 import sliderMove from '../helper/sliderMove';
+import dataStack from '../../processor/dataStack';
 
 var each = zrUtil.each;
 var asc = numberUtil.asc;

--- a/src/component/dataZoom/AxisProxy.js
+++ b/src/component/dataZoom/AxisProxy.js
@@ -282,6 +282,8 @@ AxisProxy.prototype = {
         }
 
         var targetSeries = this.getTargetSeriesModels();
+        // Calcule stack value before data extend caclulation
+        dataStack(this.ecModel);
         // Culculate data window and data extent, and record them.
         this._dataExtent = calculateDataExtent(this, this._dimName, targetSeries);
 


### PR DESCRIPTION
Calcule stack value before data extend caclulation
Close #10359 