### PR TITLE
Correct subtext textAlign, add 'x', 'y' option to subtextStyle  

### DIFF
--- a/src/component/title.js
+++ b/src/component/title.js
@@ -130,7 +130,7 @@ echarts.extendComponentView({
                 text: subText,
                 x: subtextStyleModel.get('x'),
                 textFill: subtextStyleModel.getTextColor(),
-                y: textRect.height + titleModel.get('itemGap'),
+                y: textRect.height + titleModel.get('itemGap') + (subtextStyleModel.get('y') || 0),
                 textVerticalAlign: 'top'
             }, {disableBox: true}),
             z2: 10

--- a/src/component/title.js
+++ b/src/component/title.js
@@ -109,6 +109,7 @@ echarts.extendComponentView({
         var subtextStyleModel = titleModel.getModel('subtextStyle');
 
         var textAlign = titleModel.get('textAlign');
+        var subtextAlign = subtextStyleModel.get('align');
         var textVerticalAlign = zrUtil.retrieve2(
             titleModel.get('textBaseline'), titleModel.get('textVerticalAlign')
         );
@@ -127,6 +128,7 @@ echarts.extendComponentView({
         var subTextEl = new graphic.Text({
             style: graphic.setTextStyle({}, subtextStyleModel, {
                 text: subText,
+                x: subtextStyleModel.get('x'),
                 textFill: subtextStyleModel.getTextColor(),
                 y: textRect.height + titleModel.get('itemGap'),
                 textVerticalAlign: 'top'
@@ -209,7 +211,9 @@ echarts.extendComponentView({
             textVerticalAlign: textVerticalAlign
         };
         textEl.setStyle(alignStyle);
-        subTextEl.setStyle(alignStyle);
+        subTextEl.setStyle({
+            textAlign: subtextAlign || textAlign
+        });
 
         // Render background
         // Get groupRect again because textAlign has been changed


### PR DESCRIPTION
Few options is missing in document: option.title.x and option.title.y. 
option.title.x is horizontal baseline, option.title.y is vertical baseline,

Add two options to subtextStyle: title.subtextStyle.x is offsetX base on option.title.x and title.subtextStyle.y is offsetY base on option.title.y

I will create a PR in echarts-doc to add those infos.

Inspiration came from this issue https://github.com/apache/incubator-echarts/issues/9980