### PR TITLE
Fix axis scale is working when max or min is set (#10389)

### DIFF
--- a/src/component/dataZoom/AxisProxy.js
+++ b/src/component/dataZoom/AxisProxy.js
@@ -473,7 +473,7 @@ function fixExtentByAxis(axisProxy, dataExtent) {
         dataExtent[1] = axisDataLen > 0 ? axisDataLen - 1 : NaN;
     }
 
-    if (!axisModel.get('scale', true) && !(max || min)) {
+    if (!axisModel.get('scale', true) && !(max != null || min != null)) {
         dataExtent[0] > 0 && (dataExtent[0] = 0);
         dataExtent[1] < 0 && (dataExtent[1] = 0);
     }

--- a/src/component/dataZoom/AxisProxy.js
+++ b/src/component/dataZoom/AxisProxy.js
@@ -473,7 +473,7 @@ function fixExtentByAxis(axisProxy, dataExtent) {
         dataExtent[1] = axisDataLen > 0 ? axisDataLen - 1 : NaN;
     }
 
-    if (!axisModel.get('scale', true)) {
+    if (!axisModel.get('scale', true) && !(max || min)) {
         dataExtent[0] > 0 && (dataExtent[0] = 0);
         dataExtent[1] < 0 && (dataExtent[1] = 0);
     }


### PR DESCRIPTION
According to documentation axis scale shouldn't work if min or max is set.
https://echarts.apache.org/option.html#xAxis.scale

Close #10389 