### PR TITLE
修复symbol使用Function时控制台提示symbolType.indexOf is not a function

### DIFF
--- a/src/component/marker/MarkPointView.js
+++ b/src/component/marker/MarkPointView.js
@@ -102,6 +102,10 @@ export default MarkerView.extend({
 
         mpData.each(function (idx) {
             var itemModel = mpData.getItemModel(idx);
+            var symbol = itemModel.getShallow('symbol');
+            if (typeof symbol === 'function') {
+                symbol = symbol(mpModel.getRawValue(idx), mpModel.getDataParams(idx));
+            }
             var symbolSize = itemModel.getShallow('symbolSize');
             if (typeof symbolSize === 'function') {
                 // FIXME 这里不兼容 ECharts 2.x，2.x 貌似参数是整个数据？
@@ -113,7 +117,7 @@ export default MarkerView.extend({
                 symbolSize: symbolSize,
                 color: itemModel.get('itemStyle.color')
                     || seriesData.getVisual('color'),
-                symbol: itemModel.getShallow('symbol')
+                symbol: symbol
             });
         });
 

--- a/src/util/symbol.js
+++ b/src/util/symbol.js
@@ -332,11 +332,15 @@ function symbolPathSetColor(color, innerColor) {
 export function createSymbol(symbolType, x, y, w, h, color, keepAspect) {
     // TODO Support image object, DynamicImage.
 
+    var isFunction = typeof symbolType === 'function'
+    if (isFunction) {
+        symbolType = symbolType();
+    }
+    var symbolPath;
     var isEmpty = symbolType.indexOf('empty') === 0;
     if (isEmpty) {
         symbolType = symbolType.substr(5, 1).toLowerCase() + symbolType.substr(6);
     }
-    var symbolPath;
 
     if (symbolType.indexOf('image://') === 0) {
         symbolPath = graphic.makeImage(


### PR DESCRIPTION
当尝试使用这种方式时，控制台报错`symbolType.indexOf is not a function`,我尝试过3.8到4.2.1都没有解决。
```js
 symbol: function (value) {
            if (value > 200) {
                return 'circle'
            }
            return 'rect'
        }
```
[在这个#10440中，](https://github.com/apache/incubator-echarts/issues/10440)，他说已修复，但是我发现并没有修复，可以看这个https://gallery.echartsjs.com/editor.html?c=xJRpq5QC2j&v=2

然后我去看源码，发现`util/symbol.js`中的`createSymbol`方法第一句话是
```js
var isEmpty = symbolType.indexOf('empty') === 0;//当symbolType为function时，他是不存在indexOf方法的，所以会报控制台的错误
```
在`util/symbol.js`的309行增加：
```js
var isFunction = typeof symbolType === 'function'  //判断是否为函数
    if (isFunction) {
        symbolType = symbolType()
    }
```
在`makrt/MarkPointView.js`118行中增加：
```js
// 当symbol是函数的时候给他传递数据
var symbol = itemModel.getShallow('symbol');
 if (typeof symbol === 'function') {
      symbol = symbol(mpModel.getRawValue(idx), mpModel.getDataParams(idx));
   }
```
