### PR TITLE
fix: use a clearer warning message when initing dom without size #10478

### DIFF
--- a/src/echarts.js
+++ b/src/echarts.js
@@ -1996,7 +1996,10 @@ export function init(dom, theme, opts) {
                 || (!dom.clientHeight && (!opts || opts.height == null))
             )
         ) {
-            console.warn('Can\'t get dom width or height');
+            console.warn('Can\'t get DOM width or height. Please check '
+                + 'dom.clientWidth and dom.clientHeight. They should not be 0.'
+                + 'For example, you may need to call this in the callback '
+                + 'of window.onload.');
         }
     }
 


### PR DESCRIPTION
fix: use a clearer warning message when initing dom without size #10478

The original warning message when calling `chart.init` without DOM `clientWidth` or `clientHeight` is:
```
Can\'t get DOM width or height.
```

This may cause some confusion to users and they may not know how to fix this.
In this PR, a clearer warning message is provided.