### PR TITLE
fix: bug when graph data is number typed. Fix #10485

### DIFF
--- a/src/data/Graph.js
+++ b/src/data/Graph.js
@@ -101,7 +101,7 @@ graphProto.isDirected = function () {
  * @param {number} [dataIndex]
  */
 graphProto.addNode = function (id, dataIndex) {
-    id = id || ('' + dataIndex);
+    id = id == null ? ('' + dataIndex) : ('' + id);
 
     var nodesMap = this._nodesMap;
 


### PR DESCRIPTION
When data `id` in graph series is in number typed zero `0`, it will use `dataIndex` instead of `id`, which may not be expected by the user since it's expected to use `id` rather than `dataIndex`, like in the case of #10485.

Also, I found that there is no `id` entry in the document in the graph series section. Should I add it?