### PR TITLE
Fix axisPointer label padding not working.

### DIFF
--- a/src/component/axisPointer/viewHelper.js
+++ b/src/component/axisPointer/viewHelper.js
@@ -93,6 +93,7 @@ export function buildLabelElOption(
             textFont: font,
             textFill: labelModel.getTextColor(),
             textPosition: 'inside',
+            textPadding: paddings,
             fill: bgColor,
             stroke: labelModel.get('borderColor') || 'transparent',
             lineWidth: labelModel.get('borderWidth') || 0,

--- a/test/tooltip-touch.html
+++ b/test/tooltip-touch.html
@@ -100,6 +100,9 @@ under the License.
                                 margin: 60
                             },
                             value: '2017-04-12', // init value
+                            label: {
+                                padding: [5, 10, 15, 20]
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
Fix #10569

With `padding: [10, 20, 30, 40]` in [this example](https://gallery.echartsjs.com/editor.html?c=xVszi2WnZ3&comment=0),

Before fix: (wrong)
<img width="203" alt="屏幕快照 2019-05-30 14 26 27" src="https://user-images.githubusercontent.com/779050/58613057-26b58f80-82e7-11e9-9aa0-31c593355081.png">

After fix: (correct)
<img width="198" alt="屏幕快照 2019-05-30 14 26 42" src="https://user-images.githubusercontent.com/779050/58613063-2cab7080-82e7-11e9-8036-4ee01bd0c73d.png">


