### PR TITLE
fix: update pointer when type is none, #fix 10570

### DIFF
--- a/src/component/axisPointer/BaseAxisPointer.js
+++ b/src/component/axisPointer/BaseAxisPointer.js
@@ -238,7 +238,7 @@ BaseAxisPointer.prototype = {
      */
     updatePointerEl: function (group, elOption, updateProps) {
         var pointerEl = inner(group).pointerEl;
-        if (pointerEl) {
+        if (pointerEl && elOption.pointer) {
             pointerEl.setStyle(elOption.pointer.style);
             updateProps(pointerEl, {shape: elOption.pointer.shape});
         }


### PR DESCRIPTION
`elOption.pointer` is `undefined` and accessing `elOption.pointer.style` causes problem.
fix #10570