### PR TITLE
fix: dispose checking for chart instance

### DIFF
--- a/src/echarts.js
+++ b/src/echarts.js
@@ -99,12 +99,12 @@ var ACTION_REG = /^[a-zA-Z0-9_]+$/;
 
 
 function createRegisterEventWithLowercaseName(method, ignoreDisposed) {
-    if (!ignoreDisposed && this._disposed) {
-        disposedWarning(this.id);
-        return;
-    }
-
     return function (eventName, handler, context) {
+        if (!ignoreDisposed && this._disposed) {
+            disposedWarning(this.id);
+            return;
+        }
+
         // Event name is all lowercase
         eventName = eventName && eventName.toLowerCase();
         Eventful.prototype[method].call(this, eventName, handler, context);


### PR DESCRIPTION
Fix and close #10926 .

Calling functions like `chart.resize()` should be warned when `chart.dispose()` was called before.
<img width="272" alt="fa50ecdb86ef0f3796c8dfabfa4a973b" src="https://user-images.githubusercontent.com/779050/62342030-089f2200-b518-11e9-8233-6b105f0a4305.png">
