### PR TITLE
fix: Bar chart overstep the scale extent

### DIFF
--- a/src/scale/Interval.js
+++ b/src/scale/Interval.js
@@ -149,6 +149,22 @@ var IntervalScale = Scale.extend({
     },
 
     /**
+     * Normalize value to linear [0, 1], return 0.5 if extent span is 0
+     * value need in the extent
+     * @param {number} val
+     * @return {number}
+     */
+    normalize: function(val) {
+        var extent = this._extent;
+        if (extent[1] === extent[0]) {
+            return 0.5;
+        }
+        val = Math.min(extent[1], Math.max(extent[0], val))
+
+        return (val - extent[0]) / (extent[1] - extent[0]);
+    },
+
+    /**
      * Nice extent.
      * @param {Object} opt
      * @param {number} [opt.splitNumber = 5] Given approx tick number


### PR DESCRIPTION
修复柱状图手动设置 scale 最大值最小值时超出坐标范围 issue

Config:

```
option = {
    xAxis: {
        type: 'category',
        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
    },
    yAxis: {
        type: 'value',
        min: 100,
        max: 180
    },
    series: [{
        data: [120, 200, 150, 80, 70, 110, 130],
        type: 'bar'},
    {
        data: [120, 200, 150, 80, 70, 110, 130],
        type: 'line'
    },
    ]
};
```

Result:

![image](https://user-images.githubusercontent.com/16217347/62820533-097b2800-bb98-11e9-9013-56bdbaeb24fd.png)

Expect:

![image](https://user-images.githubusercontent.com/16217347/62820539-1a2b9e00-bb98-11e9-9593-0b6592ded1ba.png)
