### PR TITLE
fix wording coodToData to coordToData

### DIFF
--- a/src/coord/radar/Radar.js
+++ b/src/coord/radar/Radar.js
@@ -120,7 +120,7 @@ Radar.prototype.pointToData = function (pt) {
         }
     }
 
-    return [closestAxisIdx, +(closestAxis && closestAxis.coodToData(radius))];
+    return [closestAxisIdx, +(closestAxis && closestAxis.coordToData(radius))];
 };
 
 Radar.prototype.resize = function (radarModel, api) {


### PR DESCRIPTION
I recognized something went wrong with radar chart and Axis coordinate when fixing my local charts. Please check this wording issue 