### PR TITLE
fix: remove es6 syntax

### DIFF
--- a/src/util/symbol.js
+++ b/src/util/symbol.js
@@ -270,7 +270,7 @@ var SymbolClz = graphic.extendShape({
         height: 0
     },
 
-    calculateTextPosition(out, style, rect) {
+    calculateTextPosition: function (out, style, rect) {
         var res = calculateTextPosition(out, style, rect);
         var shape = this.shape;
         if (shape && shape.symbolType === 'pin' && style.textPosition === 'inside') {


### PR DESCRIPTION
There is an es6 syntax cause uglify fail.