### PR TITLE
fix bug #11101

### DIFF
--- a/src/chart/candlestick/candlestickLayout.js
+++ b/src/chart/candlestick/candlestickLayout.js
@@ -148,7 +148,7 @@ export default {
 
         function largeProgress(params, data) {
             // Structure: [sign, x, yhigh, ylow, sign, x, yhigh, ylow, ...]
-            var points = new LargeArr(params.count * 5);
+            var points = new LargeArr(params.count * 4);
             var offset = 0;
             var point;
             var tmpIn = [];
@@ -164,7 +164,7 @@ export default {
 
                 if (isNaN(axisDimVal) || isNaN(lowestVal) || isNaN(highestVal)) {
                     points[offset++] = NaN;
-                    offset += 4;
+                    offset += 3;
                     continue;
                 }
 


### PR DESCRIPTION
The structure of the [largePoints](https://github.com/apache/incubator-echarts/blob/master/src/chart/candlestick/CandlestickView.js#L255) is `[sign, x, yhigh, ylow, sign, x, yhigh, ylow, ...]`. So the length of `largePoints` is 4000 when the count of the `data` in `dataset: {source: data}` is 1000. However, I found the length of `largePoints` is 5000 and the values are zero from 4500 to 4999.