### PR TITLE
Fix contributing doc missing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ More custom build approaches can be checked in this tutorial: [Create Custom Bui
 
 ## Contribution
 
-If you wish to debug locally, or make pull requests, please refer to [contributing](https://github.com/apache/incubator-echarts/blob/master/.github/CONTRIBUTING.md) document.
+If you wish to debug locally, or make pull requests, please refer to [contributing](https://github.com/apache/incubator-echarts/blob/master/CONTRIBUTING.md) document.
 
 ## Resources
 


### PR DESCRIPTION
contributing doc was moved to root dir. since doc fix branch in apache repo also fall behind master branch ,so merge to apache/incubator-echarts master