### PR TITLE
test: compare screenshots with smaller threshold in visual regression testing

### DIFF
--- a/test/runTest/compareScreenshot.js
+++ b/test/runTest/compareScreenshot.js
@@ -35,7 +35,7 @@ function readPNG(path) {
     });
 }
 
-module.exports = function (expectedShotPath, actualShotPath, threshold = 0.1) {
+module.exports = function (expectedShotPath, actualShotPath, threshold = 0.01) {
     return Promise.all([
         readPNG(expectedShotPath),
         readPNG(actualShotPath)


### PR DESCRIPTION
Previous threshold 0.1 is too large. It failed to detect the diff between these two images.

![map-nested-full-shot-actual](https://user-images.githubusercontent.com/841551/65502753-080e8080-def6-11e9-92ed-7e321317ad61.png)
![map-nested-full-shot-expected](https://user-images.githubusercontent.com/841551/65502754-08a71700-def6-11e9-98a9-7130b2bed765.png)
