### PR TITLE
fix(graphic): pie highlight not triggering

### DIFF
--- a/src/util/graphic.js
+++ b/src/util/graphic.js
@@ -332,7 +332,7 @@ function singleEnterEmphasis(el) {
 
     var zr = el.__zr;
 
-    var useHoverLayer = el.useHoverLayer && zr.painter.type === 'canvas';
+    var useHoverLayer = el.useHoverLayer && zr && zr.painter.type === 'canvas';
     el.__highlighted = useHoverLayer ? 'layer' : 'plain';
 
     if (el.isGroup || (!zr && el.useHoverLayer)) {

--- a/src/util/graphic.js
+++ b/src/util/graphic.js
@@ -331,12 +331,13 @@ function singleEnterEmphasis(el) {
     }
 
     var zr = el.__zr;
-    if (el.isGroup || (!zr && el.useHoverLayer)) {
-        return;
-    }
 
     var useHoverLayer = el.useHoverLayer && zr.painter.type === 'canvas';
     el.__highlighted = useHoverLayer ? 'layer' : 'plain';
+
+    if (el.isGroup || (!zr && el.useHoverLayer)) {
+        return;
+    }
 
     var elTarget = el;
     var targetStyle = el.style;


### PR DESCRIPTION
fix(graphic): pie highlight not triggering since 5661c6eaaf75b8e98fa9f92348c37842e31c3490

I tested both Canvas and SVG version with `aria-pie.html`, where the bug is reported in the first place, and `lines-stream-not-large.html` with pull request #11156, in which the bug was introduced.