### PR TITLE
fix: quantityExponent #11249

### DIFF
--- a/src/util/number.js
+++ b/src/util/number.js
@@ -394,7 +394,15 @@ export function quantity(val) {
  * @return {number}
  */
 export function quantityExponent(val) {
-    return val > 0 ? Math.floor(Math.log(val) / Math.LN10) : 0;
+    if (val === 0) {
+        return 0;
+    }
+
+    var exp = Math.floor(Math.log(val) / Math.LN10);
+    if (val / Math.pow(10, exp) >= 10) {
+        exp++;
+    }
+    return exp;
 }
 
 /**

--- a/test/ut/spec/util/number.js
+++ b/test/ut/spec/util/number.js
@@ -401,6 +401,7 @@ describe('util/number', function () {
             expect(numberUtil.quantityExponent(1234)).toEqual(3);
             expect(numberUtil.quantityExponent(1234.5678)).toEqual(3);
             expect(numberUtil.quantityExponent(10)).toEqual(1);
+            expect(numberUtil.quantityExponent(1000)).toEqual(3);
             expect(numberUtil.quantityExponent(10000)).toEqual(4);
         });
 
@@ -429,6 +430,7 @@ describe('util/number', function () {
             expect(numberUtil.quantity(1234)).toEqual(1000);
             expect(numberUtil.quantity(1234.5678)).toEqual(1000);
             expect(numberUtil.quantity(10)).toEqual(10);
+            expect(numberUtil.quantity(1000)).toEqual(1000);
             expect(numberUtil.quantity(10000)).toEqual(10000);
         });
 


### PR DESCRIPTION
# fix: quantityExponent #11249

Before the fix, two cases fail in the unit test:
```
expect(numberUtil.quantityExponent(1000)).toEqual(3);
expect(numberUtil.quantity(1000)).toEqual(1000);
```

After the fix, the test cases pass.