### PR TITLE
test(visual): sort actions meta data by keys

### DIFF
--- a/test/runTest/actions/update.js
+++ b/test/runTest/actions/update.js
@@ -30,5 +30,5 @@ glob('*.json', (err, files) => {
         const actions = JSON.parse(fs.readFileSync(file, 'utf-8'));
         result[file.replace(/.json$/, '')] = actions.length;
     });
-    fs.writeFileSync('__meta__.json', JSON.stringify(result, null, 2), 'utf-8');
+    fs.writeFileSync('__meta__.json', JSON.stringify(result, Object.keys(result).sort((a, b) => a.localeCompare(b)), 2), 'utf-8');
 });

--- a/test/runTest/store.js
+++ b/test/runTest/store.js
@@ -144,5 +144,8 @@ module.exports.updateActionsMeta = function (testName, actions) {
         metaData = {};
     }
     metaData[testName] = actions.length;
-    fs.writeFileSync(metaPath, JSON.stringify(metaData, null, 2), 'utf-8');
+
+    fs.writeFileSync(metaPath, JSON.stringify(
+        metaData, Object.keys(metaData).sort((a, b) => a.localeCompare(b)), 2
+    ), 'utf-8');
 };


### PR DESCRIPTION
Sort `__meta__.json` by keys to avoid conflicts when two branches are both trying to add actions.