### PR TITLE
fix bug #11000 Type of legend form scroll to plain

### DIFF
--- a/src/model/Global.js
+++ b/src/model/Global.js
@@ -212,7 +212,7 @@ var GlobalModel = Model.extend({
                         mainType, resultItem.keyInfo.subType, true
                     );
 
-                    if (componentModel && componentModel.constructor === ComponentModelClass.constructor) {
+                    if (componentModel && componentModel.constructor === ComponentModelClass) {
                         componentModel.name = resultItem.keyInfo.name;
                         // componentModel.settingTask && componentModel.settingTask.dirty();
                         componentModel.mergeOption(newCptOption, this);

--- a/src/model/Global.js
+++ b/src/model/Global.js
@@ -212,7 +212,7 @@ var GlobalModel = Model.extend({
                         mainType, resultItem.keyInfo.subType, true
                     );
 
-                    if (componentModel && componentModel instanceof ComponentModelClass) {
+                    if (componentModel && componentModel.constructor === ComponentModelClass.constructor) {
                         componentModel.name = resultItem.keyInfo.name;
                         // componentModel.settingTask && componentModel.settingTask.dirty();
                         componentModel.mergeOption(newCptOption, this);

--- a/test/dataZoom-extreme.html
+++ b/test/dataZoom-extreme.html
@@ -20,227 +20,272 @@ under the License.
 
 
 <html>
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="lib/esl.js"></script>
-        <script src="lib/config.js"></script>
-        <script src="lib/jquery.min.js"></script>
-        <script src="lib/facePrint.js"></script>
-        <script src="lib/testHelper.js"></script>
-        <link rel="stylesheet" href="lib/reset.css" />
-    </head>
-    <body>
-        <style>
-            .test-title {
-                background: #146402;
-                color: #fff;
-            }
-        </style>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/esl.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <style>
+        .test-title {
+            background: #146402;
+            color: #fff;
+        }
+    </style>
 
 
-        <div id="main0"></div>
-        <div id="main1"></div>
-        <div id="main2"></div>
+    <div id="main0"></div>
+    <div id="main1"></div>
+    <div id="main2"></div>
+    <div id="main3"></div>
 
 
-        <script>
+    <script>
 
-            var chart;
-            var myChart;
-            var option;
+        var chart;
+        var myChart;
+        var option;
 
-            require([
-                'echarts'/*, 'map/js/china' */
-            ], function (echarts) {
+        require([
+            'echarts'/*, 'map/js/china' */
+        ], function (echarts) {
 
-                // Thanks to <https://github.com/vision57>
-                // See <https://github.com/ecomfe/echarts/issues/7666>
+            // Thanks to <https://github.com/vision57>
+            // See <https://github.com/ecomfe/echarts/issues/7666>
 
-                function createParams() {
-                    var notMerge = true;
-                    var option = {
-                        dataZoom: [{
-                            type: 'inside'
-                        }, {
-                            type: 'slider'
-                        }],
-                        xAxis: {
-                            type: 'time'
-                        },
-                        yAxis: {
-                            type: 'value'
-                        },
-                        series: []
-                    };
-                    return {
-                        title: 'series empty, should no exception.',
-                        notMerge: notMerge,
-                        option: option,
-                        info: option
-                    };
-                }
-
-                chart = myChart = testHelper.create(echarts, 'main0', createParams());
-                if (chart) {
-                    // Set option again with notMerge mode.
-                    chart.setOption(createParams().option, true);
-                }
-            });
-
-        </script>
-
-
-
-
-
-
-
-
-
-
-        <script>
-
-            // See https://github.com/ecomfe/echarts/issues/7955
-            // Thanks to https://github.com/cbtpro
-
-            require([
-                'echarts',
-                'extension/bmap'
-            ], function (echarts) {
+            function createParams() {
+                var notMerge = true;
                 var option = {
-                    tooltip: {
-                        trigger: 'axis'
-                    },
-                    legend: {
-                    },
-                    toolbox: {
-                        feature: {
-                            saveAsImage: {}
-                        }
-                    },
+                    dataZoom: [{
+                        type: 'inside'
+                    }, {
+                        type: 'slider'
+                    }],
                     xAxis: {
-                        type: 'category',
-                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                        type: 'time'
                     },
                     yAxis: {
                         type: 'value'
                     },
-                    series: [
-                        {
-                            name:'Step Start',
-                            type:'line',
-                            step: 'start',
-                            data:[120, 132, null, 134, 90, 230, 210]
-                        },
-                        {
-                            name:'Step Middle',
-                            type:'line',
-                            step: 'middle',
-                            data:[220, 282, 201, 234, null, 430, 410]
-                        }
-                    ]
-                }
-
-                var chart = testHelper.create(echarts, 'main1', {
-                    title: 'When toolbox.dataZoom enabled, line should keep broken.',
+                    series: []
+                };
+                return {
+                    title: 'series empty, should no exception.',
+                    notMerge: notMerge,
                     option: option,
-                    button: {
-                        text: 'Click enable toolbox.dataZoom',
-                        onClick: function () {
-                            chart.setOption({
-                                toolbox: {
-                                    feature: {
-                                        dataZoom: {}
-                                    }
-                                },
-                                // xAxis: {
-                                //     type: 'category',
-                                //     data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
-                                // },
-                                // yAxis: {
-                                //     type: 'value'
-                                // },
-                                // series: [
-                                //     {
-                                //         name:'Step Start',
-                                //         type:'line',
-                                //         step: 'start',
-                                //         data:[120, 132, null, 134, 90, 230, 210]
-                                //     },
-                                //     {
-                                //         name:'Step Middle',
-                                //         type:'line',
-                                //         step: 'middle',
-                                //         data:[220, 282, 201, 234, null, 430, 410]
-                                //     },
-                                //     {
-                                //         name:'Step End',
-                                //         type:'line',
-                                //         step: 'end',
-                                //         data:[450, 432, 401, 454, 590, null, 510]
-                                //     }
-                                // ]
-                            });
-                        }
+                    info: option
+                };
+            }
+
+            chart = myChart = testHelper.create(echarts, 'main0', createParams());
+            if (chart) {
+                // Set option again with notMerge mode.
+                chart.setOption(createParams().option, true);
+            }
+        });
+
+    </script>
+
+
+
+
+
+
+
+
+
+
+    <script>
+
+        // See https://github.com/ecomfe/echarts/issues/7955
+        // Thanks to https://github.com/cbtpro
+
+        require([
+            'echarts',
+            'extension/bmap'
+        ], function (echarts) {
+            var option = {
+                tooltip: {
+                    trigger: 'axis'
+                },
+                legend: {
+                },
+                toolbox: {
+                    feature: {
+                        saveAsImage: {}
                     }
-                });
-
-            });
-        </script>
-
-
-
-
-        <script>
-
-            require([
-                'echarts',
-                'extension/bmap'
-            ], function (echarts) {
-
-                var option = {
-                    tooltip: {
-                        trigger: 'axis'
+                },
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        name: 'Step Start',
+                        type: 'line',
+                        step: 'start',
+                        data: [120, 132, null, 134, 90, 230, 210]
                     },
-                    legend: {
-                    },
-                    xAxis: {
-                    },
-                    yAxis: {
-                    },
-                    series: [
-                        {
-                            name:'Step Start',
-                            type:'line',
-                            data:[[12, 120], [23, 132], null, [19, 134], [45, 90]]
-                        },
-                        {
-                            name:'Step Middle',
-                            type:'line',
-                            data:[[42, 120], [53, 132], [null, 55], [49, 134], [15, 90]]
-                        }
-                    ]
+                    {
+                        name: 'Step Middle',
+                        type: 'line',
+                        step: 'middle',
+                        data: [220, 282, 201, 234, null, 430, 410]
+                    }
+                ]
+            }
+
+            var chart = testHelper.create(echarts, 'main1', {
+                title: 'When toolbox.dataZoom enabled, line should keep broken.',
+                option: option,
+                button: {
+                    text: 'Click enable toolbox.dataZoom',
+                    onClick: function () {
+                        chart.setOption({
+                            toolbox: {
+                                feature: {
+                                    dataZoom: {}
+                                }
+                            },
+                            // xAxis: {
+                            //     type: 'category',
+                            //     data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                            // },
+                            // yAxis: {
+                            //     type: 'value'
+                            // },
+                            // series: [
+                            //     {
+                            //         name:'Step Start',
+                            //         type:'line',
+                            //         step: 'start',
+                            //         data:[120, 132, null, 134, 90, 230, 210]
+                            //     },
+                            //     {
+                            //         name:'Step Middle',
+                            //         type:'line',
+                            //         step: 'middle',
+                            //         data:[220, 282, 201, 234, null, 430, 410]
+                            //     },
+                            //     {
+                            //         name:'Step End',
+                            //         type:'line',
+                            //         step: 'end',
+                            //         data:[450, 432, 401, 454, 590, null, 510]
+                            //     }
+                            // ]
+                        });
+                    }
                 }
-
-                var chart = testHelper.create(echarts, 'main2', {
-                    title: 'Add dataZoom, and zoom data, line should keep broken',
-                    option: option,
-                    button: {
-                        text: 'Click to add dataZoom',
-                        onClick: function () {
-                            chart.setOption({
-                                dataZoom: [{
-                                }, {
-                                    type: 'inside'
-                                }]
-                            })
-                        }
-                    }
-                });
             });
 
-        </script>
+        });
+    </script>
+
+
+
+
+    <script>
+
+        require([
+            'echarts',
+            'extension/bmap'
+        ], function (echarts) {
+
+            var option = {
+                tooltip: {
+                    trigger: 'axis'
+                },
+                legend: {
+                },
+                xAxis: {
+                },
+                yAxis: {
+                },
+                series: [
+                    {
+                        name: 'Step Start',
+                        type: 'line',
+                        data: [[12, 120], [23, 132], null, [19, 134], [45, 90]]
+                    },
+                    {
+                        name: 'Step Middle',
+                        type: 'line',
+                        data: [[42, 120], [53, 132], [null, 55], [49, 134], [15, 90]]
+                    }
+                ]
+            }
+
+            var chart = testHelper.create(echarts, 'main2', {
+                title: 'Add dataZoom, and zoom data, line should keep broken',
+                option: option,
+                button: {
+                    text: 'Click to add dataZoom',
+                    onClick: function () {
+                        chart.setOption({
+                            dataZoom: [{
+                            }, {
+                                type: 'inside'
+                            }]
+                        })
+                    }
+                }
+            });
+        });
+
+    </script>
+
+    <script>
+
+        require([
+            'echarts',
+            'extension/bmap'
+        ], function (echarts) {
+
+            var option = {
+                tooltip: {
+                    trigger: 'axis'
+                },
+                legend: {
+                },
+                dataZoom: [
+                    { type: 'slider' }
+                ],
+                xAxis: {
+                },
+                yAxis: {
+                },
+                series: [
+                    {
+                        name: 'Step Middle',
+                        type: 'line',
+                        data: [[42, 120], [53, 132], [null, 55], [49, 134], [15, 90]]
+                    }
+                ]
+            }
+
+            var chart = testHelper.create(echarts, 'main3', {
+                title: 'Add dataZoom, and the type of dataZoom should change to inside after 3s',
+                option: option
+            });
+
+            setTimeout(function () {
+                option.dataZoom[0].type = 'inside';
+                chart.setOption(option);
+            }, 3000);
+        });
+
+    </script>
 
 
 
@@ -250,5 +295,6 @@ under the License.
 
 
 
-    </body>
+</body>
+
 </html>

--- a/test/legend-scroll2plain.html
+++ b/test/legend-scroll2plain.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/esl.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <!-- <script src="ut/lib/canteen.js"></script> -->
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <style>
+    </style>
+
+
+
+    <div id="main0"></div>
+
+
+
+
+
+
+
+
+
+    <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+            var option;
+            // $.getJSON('./data/nutrients.json', function (data) {});
+
+            option = {
+                title: {
+                    text: '浏览器占比变化',
+                    subtext: '纯属虚构',
+                    top: 10,
+                    left: 10
+                },
+                tooltip: {
+                    trigger: 'item',
+                    backgroundColor: 'rgba(0,0,250,0.2)'
+                },
+                legend: {
+                    type: 'scroll',
+                    bottom: 10,
+                    data: (function () {
+                        var list = [];
+                        for (var i = 1; i <= 28; i++) {
+                            list.push(i + 2000 + '');
+                        }
+                        return list;
+                    })()
+                },
+                visualMap: {
+                    top: 'middle',
+                    right: 10,
+                    color: ['red', 'yellow'],
+                    calculable: true
+                },
+                radar: {
+                    indicator: [
+                        { text: 'IE8-', max: 400 },
+                        { text: 'IE9+', max: 400 },
+                        { text: 'Safari', max: 400 },
+                        { text: 'Firefox', max: 400 },
+                        { text: 'Chrome', max: 400 }
+                    ]
+                },
+                series: (function () {
+                    var series = [];
+                    for (var i = 1; i <= 28; i++) {
+                        series.push({
+                            name: '浏览器（数据纯属虚构）',
+                            type: 'radar',
+                            symbol: 'none',
+                            lineStyle: {
+                                width: 1
+                            },
+                            emphasis: {
+                                areaStyle: {
+                                    color: 'rgba(0,250,0,0.3)'
+                                }
+                            },
+                            data: [
+                                {
+                                    value: [
+                                        (40 - i) * 10,
+                                        (38 - i) * 4 + 60,
+                                        i * 5 + 10,
+                                        i * 9,
+                                        i * i / 2
+                                    ],
+                                    name: i + 2000 + ''
+                                }
+                            ]
+                        });
+                    }
+                    return series;
+                })()
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Test Case Description of main0',
+                    '(Muliple lines and **emphasis** are supported in description)'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+
+            setTimeout(function () {
+                option.legend.type = 'plain';
+                chart.setOption(option);
+            }, 3000);
+        });
+    </script>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
`Instanceof` can not only judge the direct constructor of the instance object, but also judge all the constructors in the prototype chain. The `componentModel` of scroll legend and the `componentModel` of plain legend both are instance of `ComponentModelClass`, so a new `componentModel` will not be created. The dataZoom also has this problem.