### PR TITLE
fix(line): overflow symbols should render if clip is false #11549

### DIFF
--- a/src/chart/line/LineView.js
+++ b/src/chart/line/LineView.js
@@ -354,7 +354,7 @@ export default ChartView.extend({
         // FIXME step not support polar
         var step = !isCoordSysPolar && seriesModel.get('step');
         var clipShapeForSymbol;
-        if (coordSys && coordSys.getArea && seriesModel.get('clip')) {
+        if (coordSys && coordSys.getArea && seriesModel.get('clip', true)) {
             clipShapeForSymbol = coordSys.getArea();
             // Avoid float number rounding error for symbol on the edge of axis extent.
             // See #7913 and `test/dataZoom-clip.html`.

--- a/src/chart/line/LineView.js
+++ b/src/chart/line/LineView.js
@@ -354,7 +354,7 @@ export default ChartView.extend({
         // FIXME step not support polar
         var step = !isCoordSysPolar && seriesModel.get('step');
         var clipShapeForSymbol;
-        if (coordSys && coordSys.getArea) {
+        if (coordSys && coordSys.getArea && seriesModel.get('clip')) {
             clipShapeForSymbol = coordSys.getArea();
             // Avoid float number rounding error for symbol on the edge of axis extent.
             // See #7913 and `test/dataZoom-clip.html`.


### PR DESCRIPTION
fix #11549.

before:
![image](https://user-images.githubusercontent.com/19756301/68086692-629de380-fe89-11e9-99ec-c3b3ea138ac6.png)

after:
![image](https://user-images.githubusercontent.com/19756301/68086700-79443a80-fe89-11e9-90ed-94674d863a63.png)
