### PR TITLE
Add a CLI script to generate visual test report markdown.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "help": "node build/build.js --help",
     "prepublish": "node build/build.js --prepublish",
     "test:visual": "node test/runTest/server.js",
+    "test:visual:report": "node test/runTest/genReport.js",
     "test": "node build/build.js",
     "mktest": "node test/build/mktest.js",
     "mktest:help": "node test/build/mktest.js -h",

--- a/test/runTest/genReport.js
+++ b/test/runTest/genReport.js
@@ -1,0 +1,162 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+// const jimp = require('jimp');
+// const marked = require('marked');
+
+const tests = JSON.parse(fs.readFileSync(
+    path.join(__dirname, 'tmp/__cache__.json'), 'utf-8'
+));
+
+const readFileAsync = util.promisify(fs.readFile);
+
+
+function resolveImagePath(imageUrl) {
+    if (!imageUrl) {
+        return '';
+    }
+
+    // The original image path is relative to the client.
+    return imageUrl.replace(/\.\.\/tmp/g, './tmp');
+}
+
+async function inlineImage(imageUrl) {
+    if (!imageUrl) {
+        return '';
+    }
+    try {
+        let fullPath = path.join(__dirname, resolveImagePath(imageUrl));
+        // let img = await jimp.read(fullPath);
+        // img.quality(70);
+        // return img.getBase64Async('image/jpeg');
+        let imgBuffer = await readFileAsync(fullPath);
+        return 'data:image/png;base64,' + imgBuffer.toString('base64');
+    }
+    catch (e) {
+        console.error(e);
+        return '';
+    }
+
+}
+
+async function genDetail(test) {
+    let shotDetail = '';
+    let prevShotDesc = '';
+    let failed = 0;
+    for (let shot of test.results) {
+        if (shot.diffRatio < 0.001) {
+            continue;
+        }
+        failed++;
+
+        // Batch same description shot
+        if (shot.desc !== prevShotDesc) {
+            shotDetail += `\n#### ${shot.desc}`;
+            prevShotDesc = shot.desc;
+        }
+
+        let [expectedUrl, actualUrl, diffUrl] = await Promise.all([
+            inlineImage(shot.expected),
+            inlineImage(shot.actual),
+            inlineImage(shot.diff)
+        ]);
+        shotDetail += `
+<div style="margin-top:10px">
+<figure style="width: 30%;display:inline-block;margin:0 10px;">
+  <img src="${expectedUrl}" style="width:100%" />
+  <figcaption>Expected ${test.expectedVersion}</figcaption>
+</figure>
+<figure style="width: 30%;display:inline-block;margin:0 10px;">
+  <img src="${actualUrl}" style="width:100%" />
+  <figcaption>Actual ${test.actualVersion}</figcaption>
+</figure>
+<figure style="width: 30%;display:inline-block;margin:0 10px;">
+  <img src="${diffUrl}" style="width:100%" />
+  <figcaption>Diff(${shot.diffRatio && shot.diffRatio.toFixed(3)})</figcaption>
+</figure>
+</div>
+`;
+    }
+    return {
+        content: shotDetail,
+        failed,
+        total: test.results.length
+    };
+}
+
+async function run() {
+    let sections = [];
+
+    let failedTest = 0;
+    for (let test of tests) {
+        let detail = await genDetail(test);
+
+        if (detail.failed > 0) {
+            failedTest++;
+            let title = `${failedTest}. ${test.name} (Failed ${detail.failed} / ${detail.total})`;
+            console.log(title);
+    //         let sectionText = `
+    // ## ${title}
+
+    // <details>
+    //   <summary>Click to expand!</summary>
+    // ${detail.content}
+    // </details>
+    //         `;
+
+            let sectionText = `
+<div style="margin-top: 100px;height: 20px;border-top: 1px solid #aaa"></div>
+<a id="${test.name}"></a>
+
+## ${title}
+${detail.content}
+    `;
+
+            sections.push({
+                content: sectionText,
+                title,
+                id: test.name
+            });
+        }
+    }
+
+    let mdText = '# Visual Regression Test Report\n\n';
+    mdText += `
+<p>Total: ${tests.length}</p>
+<p>Failed: ${failedTest}</p>
+
+`;
+    mdText += sections.map(section => {
+        return `+ [${section.title}](#${section.id}) `;
+    }).join('\n');
+    mdText += sections.map(section => section.content).join('\n\n');
+
+    fs.writeFileSync(__dirname + '/tmp-report.md', mdText, 'utf-8');
+
+    // marked(mdText, { smartLists: true }, (err, res) => {
+    //     fs.writeFileSync(__dirname + '/tmp-report.html', res, 'utf-8');
+    // });
+}
+
+run();

--- a/test/runTest/genReport.js
+++ b/test/runTest/genReport.js
@@ -77,9 +77,9 @@ async function genDetail(test) {
         }
 
         let [expectedUrl, actualUrl, diffUrl] = await Promise.all([
-            inlineImage(shot.expected),
-            inlineImage(shot.actual),
-            inlineImage(shot.diff)
+            resolveImagePath(shot.expected),
+            resolveImagePath(shot.actual),
+            resolveImagePath(shot.diff)
         ]);
         shotDetail += `
 <div style="margin-top:10px">
@@ -130,6 +130,7 @@ async function run() {
 <a id="${test.name}"></a>
 
 ## ${title}
+
 ${detail.content}
     `;
 


### PR DESCRIPTION
It is used to generate a all-in-one report file after all the visual test run.

Usage:

```bash
npm run test:visual:report
```

It will generate a `tmp-report.md` file in the `test/runTest` folder. Then you can translate this markdown file to any file you want. Like PDF.

### Q: Why not integrating it in the dashboard?

It has a lot of work(mostly UI) to be integrated. But the most wanted feature is to generate a file which can be shared and achieved for the regression testing before releasing. So I think a CLI tool is good enough for this feature.

Maybe later I can add a button on the dashboard to download the generated markdown report file.
