### PR TITLE
fix get font configs issue

### DIFF
--- a/src/util/graphic.js
+++ b/src/util/graphic.js
@@ -1071,8 +1071,7 @@ function rollbackDefaultTextStyle(style) {
 }
 
 export function getFont(opt, ecModel) {
-    // ecModel or default text style model.
-    var gTextStyleModel = ecModel || ecModel.getModel('textStyle');
+    var gTextStyleModel = ecModel && ecModel.getModel('textStyle');
     return zrUtil.trim([
         // FIXME in node-canvas fontWeight is before fontStyle
         opt.fontStyle || gTextStyleModel && gTextStyleModel.getShallow('fontStyle') || '',


### PR DESCRIPTION
The original logic will never get font configs from the `textStyle` option, and also the `ecModel` doesn't have other font configs except the `textStyle` option.