### PR TITLE
WIP(axisPointer): snapping logic WIP.

### DIFF
--- a/test/axisPointer-snap.html
+++ b/test/axisPointer-snap.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+        <div id="main1"></div>
+        <div id="main2"></div>
+
+
+
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+                    axisPointer: {
+                        snap: true
+                    }
+                },
+                yAxis: {
+                    type: 'value',
+                    axisPointer: {
+                        snap: true
+                    }
+                },
+                axisPointer: {
+                    show: true,
+                    snap: true
+                },
+                series: [{
+                    type: 'line',
+                    data: [['a', 2], ['d', 13], ['e', 40], ['g', 8]]
+                }, {
+                    type: 'line',
+                    data: [['a', 8], ['d', 10], ['e', 4], ['g', 15]]
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Snap with line charts; both axes has snap',
+                    'Hover around ["e", 8], yAxis should be at 40 rather than 8'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+
+
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option;
+
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        data: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+                        axisPointer: {
+                            show: true,
+                            snap: true
+                        }
+                    },
+                    yAxis: {
+                        type: 'value',
+                        axisPointer: {
+                            show: true,
+                            snap: false
+                        },
+                    },
+                    series: [{
+                        type: 'line',
+                        data: [['a', 2], ['d', 13], ['e', 40], ['g', 8]]
+                    }, {
+                        type: 'line',
+                        data: [['a', 8], ['d', 10], ['e', 4], ['g', 15]]
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main1', {
+                    title: [
+                        'Snap with line charts; only xAxis has snap',
+                        'Hover around ["d", 2], the first item circle should not be increased'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
+
+
+
+
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option;
+
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        data: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+                        axisPointer: {
+                            show: true,
+                            snap: false
+                        }
+                    },
+                    yAxis: {
+                        type: 'value',
+                        axisPointer: {
+                            show: true,
+                            snap: true
+                        },
+                    },
+                    series: [{
+                        type: 'line',
+                        data: [['a', 2], ['d', 13], ['e', 40], ['g', 8]]
+                    }, {
+                        type: 'line',
+                        data: [['a', 8], ['d', 10], ['e', 4], ['g', 15]]
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'Snap with line charts; only xAxis has snap',
+                        'Hover around ["d", 2], the first item circle should not be increased'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
+    </body>
+</html>
+


### PR DESCRIPTION
Fix #7651

```
/**
* If both x and y axes are snapping and one and only one of them is
* of category type, then the category axis is used as primary
* snapping, otherwise the baseAxis is used as primary snapping.
* The snapped value of the other axis is calculated from it.
*
*  4 |                 *
*  3 |       *
*  2 |            *
*  1 |  *     +
*    ---------------------
*       a    b    c    d
*
* In the above example, the x axis is in category type, and y axis
*     value.
* The *'s are data items, + is the mouse position.
*
* If both x and y axes are using snapping, then:
* 1. x axis is used as primary snapping axis because it's the only
*     category axis.
* 2. The nearest x value to the mouse is 'b', so 'b' is used as
*     snapped x value.
* 3. The corresponding y value of 'b' is 3, so 3 is used as snapped y
*     value.
* 4. So the axisPointer should be at ('b', 3).
*
* If only x is snapping, then the axisPointer should be at ('b', 1).
* If only y is snapping, then the axisPointer should be at the
*     position of +.
*/
```
