### PR TITLE
fix(polar): fix axis line not display in polar caused by #11705

### DIFF
--- a/src/component/axis/AngleAxisView.js
+++ b/src/component/axis/AngleAxisView.js
@@ -95,7 +95,7 @@ export default AxisView.extend({
     /**
      * @private
      */
-    _axisLine: function (angleAxisModel, polar, ticksAngles, radiusExtent) {
+    _axisLine: function (angleAxisModel, polar, ticksAngles, minorTickAngles, radiusExtent) {
         var lineStyleModel = angleAxisModel.getModel('axisLine.lineStyle');
 
         // extent id of the axis radius (r0 and r)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/841551/69935403-bbf04580-150f-11ea-86ee-c01535acf431.png)

Right one is not correct