### PR TITLE
Fix visualMap has error when  stops is empty array (#5801)

### DIFF
--- a/src/component/visualMap/PiecewiseModel.js
+++ b/src/component/visualMap/PiecewiseModel.js
@@ -369,6 +369,30 @@ var PiecewiseModel = VisualMapModel.extend({
             }
         }, this);
 
+        // stop needs to have something
+        if (!stops.length) {
+            // get value axis
+            var cartesian = visualMapModel.ecModel.getComponent('series').coordinateSystem;
+            var baseAxis = cartesian.getBaseAxis();
+            var valueAxis = cartesian.getOtherAxis(baseAxis);
+            var extent = valueAxis.scale.getExtent();
+            zrUtil.each(pieceList, function (piece) {
+                for (var i = 0; i < piece.interval.length; i++) {
+                    // Because CanvasRenderingContext2D doesn't support Infinity
+                    // So set stop value to axis end.
+                    var value = piece.interval[i] === -Infinity
+                        ? extent[0]
+                        : piece.interval[i] === Infinity
+                        ? extent[1]
+                        : piece.interval[i];
+                    stops.push({
+                        value: value,
+                        color: piece.visual.color
+                    });
+                }
+            });
+        }
+
         return {stops: stops, outerColors: outerColors};
     }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
In some case user just set `visualMap.piece.gt` or `visualMap.piece.lte` will cause an error


### Fixed issues
 Close #5801 

## Details

### Before: What was the problem?
![Screen Shot 2019-12-13 at 18 19 16](https://user-images.githubusercontent.com/20318608/70793104-94359300-1dd5-11ea-8f91-d98f138de626.png)



### After: How is it fixed in this PR?
![Screen Shot 2019-12-13 at 18 18 52](https://user-images.githubusercontent.com/20318608/70793113-9bf53780-1dd5-11ea-9a43-f65a8feae38c.png)

## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
