### PR TITLE
Add missing param for treemap setLabelStyle

### DIFF
--- a/src/chart/treemap/TreemapView.js
+++ b/src/chart/treemap/TreemapView.js
@@ -851,7 +851,8 @@ function renderNode(
             {
                 defaultText: isShow ? text : null,
                 autoColor: visualColor,
-                isRectText: true
+                isRectText: true,
+                labelFetcher: seriesModel
             }
         );
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Pass missing series model to setLabelStyle to retrieve label
Close #11772


### Before: What was the problem?
`emphasis.label.formatter` is not working

### After: How is it fixed in this PR?
`emphasis.label.formatter` is working
## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
