### PR TITLE
fix-11739: apply continuity line trail for effectline

### DIFF
--- a/src/chart/helper/EffectLine.js
+++ b/src/chart/helper/EffectLine.js
@@ -87,6 +87,7 @@ effectLineProto._updateEffectSymbol = function (lineData, idx) {
     symbol.attr('scale', size);
 
     this._symbolType = symbolType;
+    this._symbolScale = size;
 
     this._updateEffectAnimation(lineData, effectModel, idx);
 };
@@ -177,7 +178,7 @@ effectLineProto.updateSymbolPosition = function (symbol) {
     var cp1 = symbol.__cp1;
     var t = symbol.__t;
     var pos = symbol.position;
-    var lastPos = Array.from(pos);
+    var lastPos = [pos[0], pos[1]];
     var quadraticAt = curveUtil.quadraticAt;
     var quadraticDerivativeAt = curveUtil.quadraticDerivativeAt;
     pos[0] = quadraticAt(p1[0], cp1[0], p2[0], t);
@@ -190,25 +191,25 @@ effectLineProto.updateSymbolPosition = function (symbol) {
     symbol.rotation = -Math.atan2(ty, tx) - Math.PI / 2;
     // enable continuity trail for 'line', 'rect', 'roundRect' symbolType
     if (this._symbolType === 'line' || this._symbolType === 'rect' || this._symbolType === 'roundRect') {
-        if (
-            lastPos[0] !== 0 && lastPos[1] !== 0
-            && lastPos[0] !== p2[0] && lastPos[1] !== p2[1]
-            ) {
-            var scaleY = vec2.dist(lastPos, pos);
-            // Enhance ME: currently fix incorrect line segment when zooming or first segment of trail by this way
-            if (scaleY < this.getLineLength(symbol) / ((this._period / 1000) * 30)) {
-                symbol.attr('scale', [symbol.scale[0], scaleY * 1.05 ]);
-            }
-            // make sure the last segment render within endPoint, this may cause (lastPos[0] !== p2[0] && lastPos[1] !== p2[1]) failed
+        if (symbol.__lastT !== undefined && symbol.__lastT < symbol.__t) {
+            var scaleY = vec2.dist(lastPos, pos) * 1.05;
+            symbol.attr('scale', [symbol.scale[0], scaleY]);
+            // make sure the last segment render within endPoint
             if (t === 1) {
                 pos[0] = lastPos[0] + (pos[0] - lastPos[0]) / 2;
                 pos[1] = lastPos[1] + (pos[1] - lastPos[1]) / 2;
             }
         }
+        else if (symbol.__lastT === 1) {
+            // After first loop, symbol.__t does NOT start with 0, so connect p1 to pos directly.
+            var scaleY = 2 * vec2.dist(p1, pos);
+            symbol.attr('scale', [symbol.scale[0], scaleY ]);
+        }
         else {
-            symbol.attr('scale', [symbol.scale[0], symbol.scale[0]]);
+            symbol.attr('scale', this._symbolScale);
         }
     }
+    symbol.__lastT = symbol.__t;
     symbol.ignore = false;
 };
 

--- a/test/geo-lines.html
+++ b/test/geo-lines.html
@@ -232,9 +232,10 @@ under the License.
                         zlevel: 1,
                         effect: {
                             show: true,
-                            period: 6,
+                            period: 1,
                             trailLength: 0.7,
                             color: '#fff',
+                            symbol: 'line',
                             symbolSize: 3
                         },
                         lineStyle: {

--- a/test/geo-lines.html
+++ b/test/geo-lines.html
@@ -255,7 +255,7 @@ under the License.
                         symbolSize: 10,
                         effect: {
                             show: true,
-                            period: 6,
+                            period: 1,
                             trailLength: 0,
                             symbol: planePath,
                             symbolSize: 15


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Apply continuity line trail for effectline, currently enable for 'line', 'rect', 'roundRect' symbolType

### Fixed issues

https://github.com/apache/incubator-echarts/issues/11739

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
Effect line breaks when zooming in or at low-end device, since symbol is rendered at discrete position


<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![图片](https://user-images.githubusercontent.com/10528482/71320409-c8036d80-24e5-11ea-862d-17040ba27b34.png)

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

Applying scaled symbol to fill the gap between last position and current one

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->


![image](https://user-images.githubusercontent.com/10528482/71320659-6b09b680-24e9-11ea-879e-0ccf1aac69be.png)



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

only enable continuity trail for 'line', 'rect', 'roundRect' symbolType

### Related test cases or examples to use the new APIs

test/geo-lines.html



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
