### PR TITLE
fix https://github.com/apache/incubator-echarts/issues/11658

### DIFF
--- a/src/chart/pie/PieView.js
+++ b/src/chart/pie/PieView.js
@@ -171,7 +171,7 @@ piePieceProto.updateData = function (data, idx, firstCreate) {
     toggleItemSelected(
         this,
         data.getItemLayout(idx),
-        seriesModel.isSelected(null, idx),
+        seriesModel.isSelected(data.getName(idx)),
         seriesModel.get('selectedOffset'),
         seriesModel.get('animation')
     );


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixed issue 11658



### Fixed issues

<!--
- #11658: ...
-->


## Details

开始时候我们有5个州： 幽州, 荆州, 兖州, 益州, 西凉
幽州 是 idx = 0, isSelected = true;
当点击 legend， hide 幽州之后，idx = 0 的就变成了荆州，piePieceProto.updateData will be called 4 times, not 5. 所以 idx 会指错。需要用 getName 来定位 item。

TODO： 未来可以考虑更好的封装，而不是用 index 或者 name 来让 parent 进行操作。不过可能重构工程量较大😆
