### PR TITLE
fix(map): fix slice is not defined error on typed array. #11451

### DIFF
--- a/src/component/helper/MapDraw.js
+++ b/src/component/helper/MapDraw.js
@@ -182,7 +182,7 @@ MapDraw.prototype = {
         var group = this.group;
 
         if (geo._roamTransformable.transform) {
-            group.transform = geo._roamTransformable.transform.slice();
+            group.transform = Array.prototype.slice.call(geo._roamTransformable.transform);
             group.decomposeTransform();
         }
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

`TypedArray#slice` method is not exists on IE. Use `Array.prototype.slice` to clone the TypedArray instead.

### Fixed issues

https://github.com/apache/incubator-echarts/issues/11451
