### PR TITLE
fix(Markpoint): MarkPoint position with stack line/bar. Close #11535

### DIFF
--- a/src/component/marker/markerHelper.js
+++ b/src/component/marker/markerHelper.js
@@ -69,8 +69,8 @@ function markerTypeCalculatorWithExtent(
 
     var dataIndex = data.indicesOfNearest(calcDataDim, value)[0];
     coordArr[otherCoordIndex] = data.get(otherDataDim, dataIndex);
-    coordArr[targetCoordIndex] = data.get(targetDataDim, dataIndex);
-
+    coordArr[targetCoordIndex] = data.get(calcDataDim, dataIndex);
+    var coordArrValue = data.get(targetDataDim, dataIndex);
     // Make it simple, do not visit all stacked value to count precision.
     var precision = numberUtil.getPrecision(data.get(targetDataDim, dataIndex));
     precision = Math.min(precision, 20);
@@ -78,7 +78,7 @@ function markerTypeCalculatorWithExtent(
         coordArr[targetCoordIndex] = +coordArr[targetCoordIndex].toFixed(precision);
     }
 
-    return coordArr;
+    return [coordArr,coordArrValue];
 }
 
 var curry = zrUtil.curry;
@@ -141,12 +141,15 @@ export function dataTransform(seriesModel, item) {
             var otherCoordIndex = indexOf(dims, axisInfo.baseAxis.dim);
             var targetCoordIndex = indexOf(dims, axisInfo.valueAxis.dim);
 
-            item.coord = markerTypeCalculator[item.type](
+            var coordInfo = markerTypeCalculator[item.type](
                 data, axisInfo.baseDataDim, axisInfo.valueDataDim,
                 otherCoordIndex, targetCoordIndex
             );
-            // Force to use the value of calculated value.
-            item.value = item.coord[targetCoordIndex];
+            item.coord = coordInfo[0]
+            // Force to use the value of calculated value. 
+            // let item use the value without stack. 
+            item.value = coordInfo[1]
+
         }
         else {
             // FIXME Only has one of xAxis and yAxis.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Fixed issue where in the charts contain stacked data, the markpoint's position is not correct.
<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
#11535 
#11616 
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
The max,min,avg marker in the stacked bar or line graph with stacked data is misplaced.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/3286517/71653604-57392e00-2cfb-11ea-98b2-0b311d40ad3b.png)
![image](https://user-images.githubusercontent.com/3286517/71653644-9e272380-2cfb-11ea-9f9e-943deb12d796.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Changed markerTypeCalculatorWithExtent function in the markerHelper, let it always use the stacked data(if they have stack) to calculate marker's coordinate, and get the value from the original data.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/3286517/71653725-11309a00-2cfc-11ea-8773-65c2905c54a3.png)
![image](https://user-images.githubusercontent.com/3286517/71653681-ca42a480-2cfb-11ea-93a4-83fb4649d9dc.png)




## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
