### PR TITLE
Fix #11042 add cross-shaped color to candlestick

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,20 @@
 
 👍🎉 First off, thanks for taking the time to contribute! 🎉👍
 
-Please check out the [Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
+Please check out the [Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct.html) first.
+
+## What can you do for the ECharts community?
+
+Contributions can be made in varied ways:
+
+- Help others in the issues
+    - Help solve problems with the issues
+    - Remind the authors to provide a demo if they are reporting for a bug
+    - Try to reproduce the problem as describe in the issues
+- Make pull requests to fix bugs or implement new features
+- Mend or translate the documents
+- Discuss in the [mailing list](https://echarts.apache.org/en/maillist.html)
+- ...
 
 ## Issues
 
@@ -26,168 +39,11 @@ About our release plan, we will release a mior version at the end of every month
 
 ## Pull Requests
 
-### Finding Easy Issues to Fix
-
-You may use [difficulty: easy](https://github.com/apache/incubator-echarts/labels/difficulty%3A%20easy) label to filter issues that we think is easier to fix. These are issues that should be fixed using less time than the average. So if you wish to make some pull requests, this is where you can start with.
-
-You may also filter with [en](https://github.com/apache/incubator-echarts/issues?q=is%3Aopen+label%3A%22difficulty%3A+easy%22+label%3Aen) label for English issues only.
-
-### Coding Standard
-
-Please follow the [coding standard](https://echarts.apache.org/en/coding-standard.html) before you make any changes.
-
-### Git Message Standard
-
-(TBD)
-
-### Contact Us
-
-If you wish to fix a bug or add new features but don't know how, please discuss it with us in the [mailing list](dev@echarts.apache.org).
-
+Wiki: [How to make a pull request](https://github.com/apache/incubator-echarts/wiki/How-to-make-a-pull-request)
 
 ## How to Debug ECharts
 
-The following steps help you to set up a developing environment for ECharts.
-
-
-### 1. Clone ECharts project
-
-If you wish to make pull requests, you should **fork the ECharts project** first. Otherwise, just clone it locally.
-
-```bash
-git clone git@github.com:apache/incubator-echarts.git
-```
-
-[ZRender](https://github.com/ecomfe/zrender) is the rendering library under the hood. You need to clone it along with ECharts.
-
-```bash
-git clone git@github.com:ecomfe/zrender.git
-```
-
-We assume these projects are downloaded at `~/workspace/echarts` and `~/workspace/zrender`. But their locations can be arbitrary.
-
-
-### 2. Install dependencies
-
-```bash
-cd ~/workspace/echarts
-npm install
-cd ~/workspace/zrender
-npm install
-```
-
-Sometimes, in order to fix an issue within echarts, changes have to be made inside the codebase of zrender. To test any changes to zrender locally you can use npm's [npm link](https://docs.npmjs.com/cli/link.html) feature, for example:
-
-```bash
-cd ~/workspace/zrender
-npm link
-cd ~/workspace/echarts
-npm link zrender
-```
-
-With this, you can see that `~/workspace/echarts/node_modules/zrender` is a link to `~/workspace/zrender`.
-
-
-### 3. Run and debug
-
-To build the ECharts project and watch source file changes (including ZRender project) to rebuild:
-
-```bash
-cd ~/workspace/echarts
-node build/build.js --watch
-```
-
-To build once:
-
-```bash
-node build/build.js
-```
-
-Then, open the test cases under `~/workspace/echarts/test` in Web browser. You can add breakpoints under `src` directory. For example, in Chrome Inspect, it looks like:
-
-![Chrome inspect](./asset/contributing-inspect.png)
-
-
-### 4. Add test cases
-
-In most cases, one or more test cases should be added when developing a feature or fixing a bug.
-All of the existing test cases are in directory `~/workspace/echarts/test`.
-Check the file `~/workspace/echarts/test/dataZoom-action.html` as an example.
-
-**Organize test cases:**
-Each file can be regard as a **test suite** and each chart in the file can be regard as a **test case**,
-which contains one or multiple expected results (check points).
-If a feature or bug is related to a chart type or a component type, probably it should belongs to
-a test file named `chartOrComponentType-someSubCategory.html`. Or some common feature is related
-to multiple chart or component or has nothing to do with chart and component, probably it should
-belongs a test file named `featureName-someSubCateogory.html`.
-
-**The naming of a test file:**
-Generally speaking, the name of the test file should start with a chart type or component type
-or a common feature name (like "hoverStyle", "clip").
-
-**Add a test case:**
-If intending to add a test case, firstly try to find in the existing test files which file this
-new test case might belongs to.
-If an existing file found, add the test case to the file.
-Otherwise, add a new test file by commands as follows:
-
-```shell
-# Make a file named "bar-action.html" in directory "echarts/test" with 1 initial chart.
-npm run mktest bar-action
-# or `npm run mktest bar-action.html`
-
-# Make a file named "bar-action.html" in directory "echarts/test" with 5 initial charts.
-npm run mktest bar-action 5
-```
-
-**The expected results and the instructions of user interaction:**
-Although we have auto-visual-test tool to run tests, we should better write the expected result
-(check points) for each test cases for manual checking.
-Some cases need user interactions involved. The instructions should be written clearly.
-The expected results and the user instructions should be written in the `title` filed when
-creating a test by `testHelper.create` as follows:
-
-```js
-var chart = testHelper.create(echarts, 'main0', {
-    title: [
-        'Hover on the red circle',
-        '**A blue label** should appear on the **top of red circle**.'
-    ],
-    option: option
-});
-```
-
-
-### 5. Run test cases
-
-```bash
-# puppeteer is not in the devDependencies and needs to be installed manually
-npm install puppeteer --no-save
-npm run test:visual
-```
-
-It will run all the test cases under `~/workspace/echarts/test` automatically to compare with the previous version. You can use this to check if your code bring some breaking change.
-
-
-### 6. Check the code style
-
-The code style should follow the [Code Standard](https://echarts.apache.org/en/coding-standard.html).
-
-It is recommanded to install [eslint](https://eslint.org) plugin to in your IDE to find the invalid code style.
-Otherwise, we can also use
-```bash
-npm run lint
-```
-to check the the code style.
-
-
-### 7. Make a pull request
-
-Fork ECharts project into your own project. Checkout a branch from master branch named `fix-xxxx`, where xxxx is the issue id related. If there's no related issue, you need to create one in most cases to describe what's wrong or what new feature is required.
-
-If you are a committer of apache/incubator-echarts project, which means you have the write access to the project, you still need to push to a new branch (by `git push origin HEAD:refs/heads/fix-xxxx`) and use pull request to push your code. You cannot push code directly to `master` branch, otherwise it will be rejected by GitHub.
-
+Wiki: [How to setup the dev environment](https://github.com/apache/incubator-echarts/wiki/How-to-setup-the-dev-environment)
 
 ## Some hints about using code from other authors
 

--- a/extension-src/bmap/BMapCoordSys.js
+++ b/extension-src/bmap/BMapCoordSys.js
@@ -35,7 +35,7 @@ function BMapCoordSys(bmap, api) {
     this._projection = new BMap.MercatorProjection();
 }
 
-BMapCoordSys.prototype.dimensions = ['lng', 'lat', 'value'];
+BMapCoordSys.prototype.dimensions = ['lng', 'lat'];
 
 BMapCoordSys.prototype.setZoom = function (zoom) {
     this._zoom = zoom;

--- a/src/chart/candlestick/CandlestickSeries.js
+++ b/src/chart/candlestick/CandlestickSeries.js
@@ -64,11 +64,13 @@ var CandlestickSeries = SeriesModel.extend({
         itemStyle: {
             color: '#c23531', // 阳线 positive
             color0: '#314656', // 阴线 negative     '#c23531', '#314656'
+            color1: '#000',  // 十字星 neutral
             borderWidth: 1,
             // FIXME
             // ec2中使用的是lineStyle.color 和 lineStyle.color0
             borderColor: '#c23531',
-            borderColor0: '#314656'
+            borderColor0: '#314656',
+            borderColor1: '#000'
         },
 
         emphasis: {

--- a/src/chart/candlestick/CandlestickView.js
+++ b/src/chart/candlestick/CandlestickView.js
@@ -25,7 +25,7 @@ import {createClipPath} from '../helper/createClipPathFromCoordSys';
 
 var NORMAL_ITEM_STYLE_PATH = ['itemStyle'];
 var EMPHASIS_ITEM_STYLE_PATH = ['emphasis', 'itemStyle'];
-var SKIP_PROPS = ['color', 'color0', 'borderColor', 'borderColor0'];
+var SKIP_PROPS = ['color', 'color0', 'borderColor', 'borderColor0', 'color1', 'borderColor1'];
 
 var CandlestickView = ChartView.extend({
 

--- a/src/chart/candlestick/candlestickLayout.js
+++ b/src/chart/candlestick/candlestickLayout.js
@@ -92,7 +92,7 @@ export default {
                 );
 
                 data.setItemLayout(dataIndex, {
-                    sign: getSign(data, dataIndex, openVal, closeVal, closeDim),
+                    sign: getSign(openVal, closeVal),
                     initBaseline: openVal > closeVal
                         ? ocHighPoint[vDimIdx] : ocLowPoint[vDimIdx], // open point.
                     ends: ends,
@@ -168,7 +168,7 @@ export default {
                     continue;
                 }
 
-                points[offset++] = getSign(data, dataIndex, openVal, closeVal, closeDim);
+                points[offset++] = getSign(openVal, closeVal);
 
                 tmpIn[cDimIdx] = axisDimVal;
 
@@ -186,7 +186,7 @@ export default {
     }
 };
 
-function getSign(data, dataIndex, openVal, closeVal, closeDim) {
+function getSign(openVal, closeVal) {
     var sign;
     if (openVal > closeVal) {
         sign = -1;
@@ -195,11 +195,7 @@ function getSign(data, dataIndex, openVal, closeVal, closeDim) {
         sign = 1;
     }
     else {
-        sign = dataIndex > 0
-            // If close === open, compare with close of last record
-            ? (data.get(closeDim, dataIndex - 1) <= closeVal ? 1 : -1)
-            // No record of previous, set to be positive
-            : 1;
+        sign = 0;
     }
 
     return sign;

--- a/src/chart/candlestick/candlestickVisual.js
+++ b/src/chart/candlestick/candlestickVisual.js
@@ -21,8 +21,10 @@ import createRenderPlanner from '../helper/createRenderPlanner';
 
 var positiveBorderColorQuery = ['itemStyle', 'borderColor'];
 var negativeBorderColorQuery = ['itemStyle', 'borderColor0'];
+var neutralBorderColorQuery = ['itemStyle', 'borderColor1'];
 var positiveColorQuery = ['itemStyle', 'color'];
 var negativeColorQuery = ['itemStyle', 'color0'];
+var neutralColorQuery = ['itemStyle', 'color1'];
 
 export default {
 
@@ -42,8 +44,10 @@ export default {
             legendSymbol: 'roundRect',
             colorP: getColor(1, seriesModel),
             colorN: getColor(-1, seriesModel),
+            colorNeutralColor: getColor(0, seriesModel),
             borderColorP: getBorderColor(1, seriesModel),
-            borderColorN: getBorderColor(-1, seriesModel)
+            borderColorN: getBorderColor(-1, seriesModel),
+            borderColorNeutralColor: getBorderColor(0, seriesModel)
         });
 
         // Only visible series has each data be visual encoded
@@ -71,15 +75,47 @@ export default {
         }
 
         function getColor(sign, model) {
+            var colorQuery = getColorOrBorderColorQuery(sign, 'color');
+
             return model.get(
-                sign > 0 ? positiveColorQuery : negativeColorQuery
+                colorQuery
             );
         }
 
         function getBorderColor(sign, model) {
+            var borderColorQuery = getColorOrBorderColorQuery(sign, 'borderColor');
+
             return model.get(
-                sign > 0 ? positiveBorderColorQuery : negativeBorderColorQuery
+                borderColorQuery
             );
+        }
+
+        function getColorOrBorderColorQuery(sign, colorType) {
+            var colorQuery;
+            var colorAndBorderColor = {
+                color: {
+                    neutral: neutralColorQuery,
+                    positive: positiveColorQuery,
+                    negative: negativeColorQuery
+                },
+                borderColor: {
+                    neutral: neutralBorderColorQuery,
+                    positive: positiveBorderColorQuery,
+                    negative: negativeBorderColorQuery
+                }
+            };
+
+            if (sign === 0) {
+                colorQuery = colorAndBorderColor[colorType].neutral;
+            }
+            else if (sign > 0) {
+                colorQuery = colorAndBorderColor[colorType].positive;
+            }
+            else {
+                colorQuery = colorAndBorderColor[colorType].negative;
+            }
+
+            return colorQuery;
         }
 
     }

--- a/src/theme/dark.js
+++ b/src/theme/dark.js
@@ -145,8 +145,10 @@ var theme = {
             normal: {
                 color: '#FD1050',
                 color0: '#0CF49B',
+                color1: '#FFF',
                 borderColor: '#FD1050',
-                borderColor0: '#0CF49B'
+                borderColor0: '#0CF49B',
+                borderColor1: '#FFF'
             }
         }
     }

--- a/test/candlestick-empty.html
+++ b/test/candlestick-empty.html
@@ -136,10 +136,10 @@ under the License.
                             itemStyle: {
                                 color: '#ec0000',
                                 color0: '#00da3c',
-                                color1: 'red',
+                                // color1: 'gray',
                                 borderColor: '#8A0000',
                                 borderColor0: '#008F28',
-                                bordercolor1: 'red'
+                                // borderColor1: 'gray'
                             }
                         },
                         // {

--- a/test/candlestick-empty.html
+++ b/test/candlestick-empty.html
@@ -64,7 +64,7 @@ under the License.
 
                 var data0 = splitData([
                     ['2013/1/24'],
-                    ['2013/1/25', 2300,2291.3,2288.26,2308.38],
+                    ['2013/1/25', 2300,2300,2288.26,2308.38],
                     ['2013/1/28'],
                     ['2013/1/29', 2347.22,2358.98,2337.35,2363.8],
                     ['2013/1/30'],
@@ -132,7 +132,15 @@ under the License.
                         {
                             name: '日K',
                             type: 'candlestick',
-                            data: data0.values
+                            data: data0.values,
+                            itemStyle: {
+                                color: '#ec0000',
+                                color0: '#00da3c',
+                                color1: 'red',
+                                borderColor: '#8A0000',
+                                borderColor0: '#008F28',
+                                bordercolor1: 'red'
+                            }
                         },
                         // {
                         //     name: '日K 空',


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing


### What does this PR do?

add cross-shaped color to candlestick when the openVal equal closeVal



### Fixed issues

#11042


## Details

### Before: What was the problem?

can not set the cross color(when the open value equal close value)



### After: How is it fixed in this PR?

set cross-shaped color 
the default color is '#000' and '#FFF'(dark theme)


## Usage

### Are there any API changes?

- [ ] The API has been changed.

series-candlestick.itemStyle.color1: 
series-candlestick.itemStyle.borderColor1



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
