### PR TITLE
fix: tweak 51f836de (fix subpixel optimize with no lineWidth in zrender)

### DIFF
--- a/src/component/title.js
+++ b/src/component/title.js
@@ -226,7 +226,7 @@ echarts.extendComponentView({
                 r: titleModel.get('borderRadius')
             },
             style: style,
-            subPixelOptimize: !!style.lineWidth,
+            subPixelOptimize: true,
             silent: true
         });
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

fix subpixel optimize with no lineWidth in zrender.

The logic in https://github.com/ecomfe/zrender/pull/557


### Related original issues

#11874 #11891
