### PR TITLE
fix: fix candlestick throw error when some series filtered by legend.

### DIFF
--- a/src/chart/candlestick/candlestickVisual.js
+++ b/src/chart/candlestick/candlestickVisual.js
@@ -36,7 +36,6 @@ export default {
     reset: function (seriesModel, ecModel) {
 
         var data = seriesModel.getData();
-        var isLargeRender = seriesModel.pipelineContext.large;
 
         data.setVisual({
             legendSymbol: 'roundRect',
@@ -51,6 +50,7 @@ export default {
             return;
         }
 
+        var isLargeRender = seriesModel.pipelineContext.large;
         return !isLargeRender && {progress: progress};
 
 

--- a/src/chart/helper/createRenderPlanner.js
+++ b/src/chart/helper/createRenderPlanner.js
@@ -32,8 +32,11 @@ export default function () {
         var originalLarge = fields.large;
         var originalProgressive = fields.progressiveRender;
 
-        var large = fields.large = pipelineContext.large;
-        var progressive = fields.progressiveRender = pipelineContext.progressiveRender;
+        // FIXME: if the planner works on a filtered series, `pipelineContext` does not
+        // exists. See #11611 . Probably we need to modify this structure, see the comment
+        // on `performRawSeries` in `Schedular.js`.
+        var large = fields.large = pipelineContext && pipelineContext.large;
+        var progressive = fields.progressiveRender = pipelineContext && pipelineContext.progressiveRender;
 
         return !!((originalLarge ^ large) || (originalProgressive ^ progressive)) && 'reset';
     };

--- a/src/stream/Scheduler.js
+++ b/src/stream/Scheduler.js
@@ -260,6 +260,14 @@ function performStageTasks(scheduler, stageHandlers, ecModel, payload, opt) {
                     task.dirty();
                 }
                 var performArgs = scheduler.getPerformArgs(task, opt.block);
+                // FIXME
+                // if intending to decalare `performRawSeries` in handlers, only
+                // stream-independent (specifically, data item independent) operations can be
+                // performed. Because is a series is filtered, most of the tasks will not
+                // be performed. A stream-dependent operation probably cause wrong biz logic.
+                // Perhaps we should not provide a separate callback for this case instead
+                // of providing the config `performRawSeries`. The stream-dependent operaions
+                // and stream-independent operations should better not be mixed.
                 performArgs.skip = !stageHandler.performRawSeries
                     && ecModel.isSeriesFiltered(task.context.model);
                 updatePayload(task, payload);

--- a/test/stream-filter2.html
+++ b/test/stream-filter2.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+        <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+            var option;
+
+            option = {
+                legend: {
+                    left: 'center',
+                    data: ['K', 'CK'],
+                    selected: {
+                        'K': false,
+                        'CK': true
+                    }
+                },
+                grid: [{
+                    left: '10%',
+                    right: '10%',
+                    height: '50%'
+                }],
+                xAxis: [{
+                    type: 'category',
+                    boundaryGap: true,
+                    axisLine: {onZero: false},
+                    splitLine: {show: false},
+                    data: [
+                        '2012-10-10'
+                    ]
+                }],
+                yAxis: [{
+                    scale: true,
+                    splitArea: {show: true}
+                }],
+                axisPointer: {
+                    link: [{
+                        xAxisIndex: [0, 1]
+                    }]
+                },
+                dataZoom: [
+                    {
+                        type: 'inside',
+                        xAxisIndex: [0, 0],
+                        start: 0,
+                        end: 100
+                    }
+                ],
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {type: 'line'}
+                },
+                toolbox: {
+                    show: true,
+                    feature: {
+                        dataZoom: {yAxisIndex: false},
+                        dataView: {readOnly: false},
+                        restore: {},
+                        saveAsImage: {}
+                    }
+                },
+                series: [
+                    {
+                        name: 'K',
+                        type: 'candlestick',
+                        itemStyle: {
+                            normal: {
+                                color: '#B22222',
+                                color0: '#008000',
+                                opacity: 0.4
+                            }
+                        },
+                        data: [
+                            [
+                                2993.9617,
+                                3007.8834,
+                                2989.8125,
+                                3026.3834,
+                                20861480200.0,
+                                221201755725.0
+                            ]
+                        ]
+                    },
+                    {
+                        name: 'CK',
+                        type: 'candlestick',
+                        data: [
+                            [
+                                2934.3873,
+                                2954.6415,
+                                2934.3873,
+                                2954.6415
+                            ]
+                        ]
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'The chart should rendered normally when a series is filtered'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

fix candlestick throw error when some series filtered by legend. 


### Fixed issues

fix #11611

## Details

### Before: What was the problem?

Throw error. see the case in #11611 .


### After: How is it fixed in this PR?

Fix it by null checking. 
But it might not be a best way.
If intending to declare `performRawSeries` in handlers, only
stream-independent (specifically, data item independent) operations can be
performed. Because is a series is filtered, most of the tasks will not
be performed. A stream-dependent operation probably cause wrong biz logic.
Perhaps we should not provide a separate callback for this case instead
of providing the config `performRawSeries`. The stream-dependent operations
and stream-independent operations should better not be mixed.
It can be down in future version because some more tests and check are needed,
now that the deadline of 4.7.0 is coming.


### Related test cases or examples to use the new APIs

`test/stream-filter2.html`.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
