### PR TITLE
Fix 11781: save svg image with toolbox

### DIFF
--- a/src/component/toolbox/feature/SaveAsImage.js
+++ b/src/component/toolbox/feature/SaveAsImage.js
@@ -50,7 +50,8 @@ var proto = SaveAsImage.prototype;
 proto.onclick = function (ecModel, api) {
     var model = this.model;
     var title = model.get('name') || ecModel.get('title.0.text') || 'echarts';
-    var type = model.get('type', true) || 'png';
+    var isSvg = api.getZr().painter.getType() === 'svg';
+    var type = isSvg ? 'svg' : model.get('type', true) || 'png';
     var url = api.getConnectedDataURL({
         type: type,
         backgroundColor: model.get('backgroundColor', true)

--- a/src/echarts.js
+++ b/src/echarts.js
@@ -473,7 +473,7 @@ echartsProto.getRenderedCanvas = function (opts) {
  * Get svg data url
  * @return {string}
  */
-echartsProto.getSvgDataUrl = function () {
+echartsProto.getSvgDataURL = function () {
     if (!env.svgSupported) {
         return;
     }
@@ -485,7 +485,7 @@ echartsProto.getSvgDataUrl = function () {
         el.stopAnimation(true);
     });
 
-    return zr.painter.pathToDataUrl();
+    return zr.painter.toDataURL();
 };
 
 /**
@@ -521,7 +521,7 @@ echartsProto.getDataURL = function (opts) {
     });
 
     var url = this._zr.painter.getType() === 'svg'
-        ? this.getSvgDataUrl()
+        ? this.getSvgDataURL()
         : this.getRenderedCanvas(opts).toDataURL(
             'image/' + (opts && opts.type || 'png')
         );
@@ -611,7 +611,7 @@ echartsProto.getConnectedDataURL = function (opts) {
             }
 
             zr.refreshImmediately();
-            return zr.painter.pathToDataUrl();
+            return zr.painter.toDataURL();
         }
         else {
             // Background between the charts

--- a/src/echarts.js
+++ b/src/echarts.js
@@ -550,6 +550,7 @@ echartsProto.getConnectedDataURL = function (opts) {
     if (!env.canvasSupported) {
         return;
     }
+    var isSvg = opts.type === 'svg';
     var groupId = this.group;
     var mathMin = Math.min;
     var mathMax = Math.max;
@@ -564,9 +565,9 @@ echartsProto.getConnectedDataURL = function (opts) {
 
         zrUtil.each(instances, function (chart, id) {
             if (chart.group === groupId) {
-                var canvas = chart.getRenderedCanvas(
-                    zrUtil.clone(opts)
-                );
+                var canvas = isSvg
+                    ? chart.getZr().painter.getSvgDom().innerHTML
+                    : chart.getRenderedCanvas(zrUtil.clone(opts));
                 var boundingRect = chart.getDom().getBoundingClientRect();
                 left = mathMin(boundingRect.left, left);
                 top = mathMin(boundingRect.top, top);
@@ -587,38 +588,61 @@ echartsProto.getConnectedDataURL = function (opts) {
         var width = right - left;
         var height = bottom - top;
         var targetCanvas = zrUtil.createCanvas();
-        targetCanvas.width = width;
-        targetCanvas.height = height;
-        var zr = zrender.init(targetCanvas);
-
-        // Background between the charts
-        if (opts.connectedBackgroundColor) {
-            zr.add(new graphic.Rect({
-                shape: {
-                    x: 0,
-                    y: 0,
-                    width: width,
-                    height: height
-                },
-                style: {
-                    fill: opts.connectedBackgroundColor
-                }
-            }));
-        }
-
-        each(canvasList, function (item) {
-            var img = new graphic.Image({
-                style: {
-                    x: item.left * dpr - left,
-                    y: item.top * dpr - top,
-                    image: item.dom
-                }
-            });
-            zr.add(img);
+        var zr = zrender.init(targetCanvas, {
+            renderer: isSvg ? 'svg' : 'canvas'
         });
-        zr.refreshImmediately();
+        zr.resize({
+            width: width,
+            height: height
+        });
 
-        return targetCanvas.toDataURL('image/' + (opts && opts.type || 'png'));
+        if (isSvg) {
+            var content = '';
+            each(canvasList, function (item) {
+                var x = item.left - left;
+                var y = item.top - top;
+                content += '<g transform="translate(' + x + ","
+                    + y + ')">' + item.dom + '</g>';
+            });
+            zr.painter.getSvgRoot().innerHTML = content;
+
+            if (opts.connectedBackgroundColor) {
+                zr.painter.setBackgroundColor(opts.connectedBackgroundColor);
+            }
+
+            zr.refreshImmediately();
+            return zr.painter.pathToDataUrl();
+        }
+        else {
+            // Background between the charts
+            if (opts.connectedBackgroundColor) {
+                zr.add(new graphic.Rect({
+                    shape: {
+                        x: 0,
+                        y: 0,
+                        width: width,
+                        height: height
+                    },
+                    style: {
+                        fill: opts.connectedBackgroundColor
+                    }
+                }));
+            }
+
+            each(canvasList, function (item) {
+                var img = new graphic.Image({
+                    style: {
+                        x: item.left * dpr - left,
+                        y: item.top * dpr - top,
+                        image: item.dom
+                    }
+                });
+                zr.add(img);
+            });
+
+            zr.refreshImmediately();
+            return targetCanvas.toDataURL('image/' + (opts && opts.type || 'png'));
+        }
     }
     else {
         return this.getDataURL(opts);

--- a/test/toolbox-saveImage-background-svg.html
+++ b/test/toolbox-saveImage-background-svg.html
@@ -47,7 +47,7 @@ under the License.
 
     <div id="chart0" class="chart"></div>
 
-    <p>The background of the exported png using toolbox should be yellow.</p>
+    <p>The background of the exported svg using toolbox should be yellow.</p>
 
     <div id="chart1" class="chart"></div>
     <div id="chart2" class="chart"></div>

--- a/test/toolbox-saveImage-background-svg.html
+++ b/test/toolbox-saveImage-background-svg.html
@@ -1,0 +1,208 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+License); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script src="lib/esl.js"></script>
+    <script src="lib/config.js"></script>
+    <meta name="viewport" content="width=device-width", initial-scale="1" />
+</head>
+
+<body>
+    <style>
+        html,
+        body {
+            width: 80%;
+            height: 100%;
+            margin: 0;
+        }
+
+        .chart {
+            background: #fff;
+            margin-bottom: 20px;
+            width: 80%;
+            height: 200px;
+        }
+    </style>
+
+    <p>SVG charts should export svg images without extra setting.</p>
+
+    <div id="chart0" class="chart"></div>
+
+    <p>The background of the exported png using toolbox should be yellow.</p>
+
+    <div id="chart1" class="chart"></div>
+    <div id="chart2" class="chart"></div>
+
+    <script>
+        require([
+            'echarts'
+        ], function (echarts) {
+            var chart0 = echarts.init(document.getElementById('chart0'), null, {
+                renderer: 'svg'
+            });
+            option = {
+                backgroundColor: '#aff',
+                toolbox: {
+                    feature: {
+                        saveAsImage: {
+                            show: true,
+                            title: 'Save as image'
+                        }
+                    },
+                    show: true,
+                    itemGap: 1,
+                    top: 20,
+                    right: 35
+                },
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [{
+                    data: [820, 932, 901, 934, 1290, 1330, 1320],
+                    type: 'line'
+                }]
+            };
+            chart0.setOption(option);
+        });
+
+        require([
+            'echarts'
+        ], function (echarts) {
+            var chart1 = echarts.init(document.getElementById('chart1'), null, {
+                renderer: 'svg'
+            });
+            var chart2 = echarts.init(document.getElementById('chart2'), null, {
+                renderer: 'svg'
+            });
+
+            var data1 = [];
+
+            var symbolCount = 6;
+
+            for (var i = 0; i < 100; i++) {
+                data1.push([
+                    Math.random() * 5,
+                    Math.random() * 4,
+                    Math.random() * 20,
+                    Math.round(Math.random() * (symbolCount - 1))
+                ]);
+            }
+
+            chart1.setOption({
+                backgroundColor: 'red',
+                toolbox: {
+                    feature: {
+                        saveAsImage: {
+                            show: true,
+                            title: 'Save as image',
+                            type: 'png',
+                            connectedBackgroundColor: 'yellow'
+                        },
+                        dataZoom: {
+                            yAxisIndex: 'none',
+                            show: true,
+                            title: {
+                                zoom: 'Zoom in',
+                                back: 'Zoom out'
+                            },
+                        }
+                    },
+                    show: true,
+                    itemGap: 1,
+                    top: 20,
+                    right: 35
+                },
+                legend: {
+                    top: 50,
+                    data: ['scatter']
+                },
+                tooltip: {
+                    formatter: '{c}'
+                },
+                grid: {
+                    top: '26%',
+                    bottom: '26%'
+                },
+                xAxis: {
+                    type: 'value',
+                    splitLine: {
+                        show: false
+                    }
+                },
+                yAxis: {
+                    type: 'value',
+                    splitLine: {
+                        show: false
+                    }
+                },
+                series: [{
+                    name: 'scatter',
+                    type: 'scatter',
+                    symbolSize: 30,
+                    data: data1
+                }]
+            });
+
+            chart2.setOption({
+                backgroundColor: 'green',
+                legend: {
+                    top: 50,
+                    data: ['scatter']
+                },
+                tooltip: {
+                    formatter: '{c}'
+                },
+                grid: {
+                    top: '26%',
+                    bottom: '26%'
+                },
+                xAxis: {
+                    type: 'value',
+                    splitLine: {
+                        show: false
+                    }
+                },
+                yAxis: {
+                    type: 'value',
+                    splitLine: {
+                        show: false
+                    }
+                },
+                series: [{
+                    name: 'scatter',
+                    type: 'scatter',
+                    symbolSize: 30,
+                    data: data1
+                }]
+            });
+
+            echarts.connect([chart1, chart2]);
+
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

To support saving SVG images with toolbox. Also works for connected charts.

### Fixed issues

- #11781: Bug: download svg image with toolbox


## Details

### Before: What was the problem?

1. Default suffix of the downloaded file with SVG charts was `.png` if [saveAsImage.type](https://echarts.apache.org/zh/option.html#toolbox.feature.saveAsImage.type) is not set manually, which should be `.svg` because the downloaded file is an SVG file.
2. The downloaded SVG has an error in it and cannot be opened even after changing the file suffix to be `.svg`
3. It didn't work for connected charts.

### After: How is it fixed in this PR?

1. The default suffix is `.svg` if the chart renderer is `'svg'`.
2. No error after the fix.
3. It works for connected charts now and the background is set to be [connectedBackgroundColor](https://echarts.apache.org/zh/option.html#toolbox.feature.saveAsImage.connectedBackgroundColor), which is the same as Canvas behavior.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

Test case: toolbox-saveImage-background-svg.html

The saved SVG file should look the same as the charts.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
