### PR TITLE
Fix: Calendar fix for DST

### DIFF
--- a/src/coord/calendar/Calendar.js
+++ b/src/coord/calendar/Calendar.js
@@ -372,8 +372,8 @@ Calendar.prototype = {
             range.reverse();
         }
 
-        var allDay = Math.floor(range[1].time / PROXIMATE_ONE_DAY)
-            - Math.floor(range[0].time / PROXIMATE_ONE_DAY) + 1;
+        var allDay =
+            Math.round((range[1].time - range[0].time) / PROXIMATE_ONE_DAY) + 1;
 
         // Consider case:
         // Firstly set system timezone as "Time Zone: America/Toronto",


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fixes calendar chart layout when user is in a timezone with DST

### Fixed issues

<!--
- #xxxx: ...
-->

https://github.com/apache/incubator-echarts/issues/12143
https://github.com/apache/incubator-echarts/issues/10430


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

When user is in a timezone with DST, the last several months of the year on the calendar chart begin to overlap eachother.

![74432963-69a89a80-4e57-11ea-82b1-8320fea36821](https://user-images.githubusercontent.com/10422754/74856158-9407c580-5339-11ea-8f36-28ffc785b453.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

The fix is based on the solution from https://github.com/apache/incubator-echarts/issues/10430

![Screenshot 2020-02-19 at 17 04 17](https://user-images.githubusercontent.com/10422754/74856369-eba63100-5339-11ea-8fe8-e177b7653870.png)

There is currently another PR attempting to fix this problem here: https://github.com/apache/incubator-echarts/pull/12081 - however, from testing, it did not appear to correct the problem.

## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
