### PR TITLE
Fix/graph line label: keep the original distance between line label and line.

### DIFF
--- a/src/chart/graph/GraphSeries.js
+++ b/src/chart/graph/GraphSeries.js
@@ -242,7 +242,8 @@ var GraphSeries = echarts.extendSeriesModel({
         edgeSymbol: ['none', 'none'],
         edgeSymbolSize: 10,
         edgeLabel: {
-            position: 'middle'
+            position: 'middle',
+            distance: 5
         },
 
         draggable: false,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->


89221c831217f0b17da5f88d6f3c2426ca64ee9a provide new line label position config,
enhanced the original hard code `distance` to `option` configurable.
This PR add default option to graph, to make the the default distance between line label and line the same as before.
