### PR TITLE
Feat: use auto calculate if min /max is null

### DIFF
--- a/src/coord/axisHelper.js
+++ b/src/coord/axisHelper.js
@@ -42,6 +42,8 @@ export function getScaleExtent(scale, model) {
 
     var min = model.getMin();
     var max = model.getMax();
+    var fixMin = min != null;
+    var fixMax = max != null;
     var originalExtent = scale.getExtent();
 
     var axisDataLen;
@@ -128,11 +130,11 @@ export function getScaleExtent(scale, model) {
     // Evaluate if axis needs cross zero
     if (model.getNeedCrossZero()) {
         // Axis is over zero and min is not set
-        if (min > 0 && max > 0 && !(min != null)) {
+        if (min > 0 && max > 0 && !fixMin) {
             min = 0;
         }
         // Axis is under zero and max is not set
-        if (min < 0 && max < 0 && !(max != null)) {
+        if (min < 0 && max < 0 && !fixMax) {
             max = 0;
         }
     }

--- a/src/echarts.js
+++ b/src/echarts.js
@@ -601,7 +601,7 @@ echartsProto.getConnectedDataURL = function (opts) {
             each(canvasList, function (item) {
                 var x = item.left - left;
                 var y = item.top - top;
-                content += '<g transform="translate(' + x + ","
+                content += '<g transform="translate(' + x + ','
                     + y + ')">' + item.dom + '</g>';
             });
             zr.painter.getSvgRoot().innerHTML = content;

--- a/test/axis-extrema.html
+++ b/test/axis-extrema.html
@@ -68,6 +68,9 @@ under the License.
         <h2>cartesian value axis | xAxis: {min: function, max: function}</h2>
         <div class="chart" id="main4.1"></div>
 
+        <h2>cartesian value axis | xAxis: {min: function, max: function}</h2>
+        <div class="chart" id="main4.2"></div>
+
         <h2>cartesian time axis | xAxis: {min: 'dataMin', max: 'dataMax'}</h2>
         <div class="chart" id="main5"></div>
 
@@ -463,6 +466,42 @@ under the License.
             });
         </script>
 
+        <script>
+            makeChart('main4.2', {
+                legend: {
+                    data: ['no point', 'one point', 'two points'],
+                    selectedMode: 'single'
+                },
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'line'
+                    }
+                },
+                xAxis: {
+                    min: function (value) {
+                        return null
+                    },
+                    max: function (value) {
+                        return null;
+                    }
+                },
+                yAxis: {},
+                series: [{
+                    name: 'no point',
+                    type: 'line',
+                    data: []
+                }, {
+                    name: 'one point',
+                    type: 'line',
+                    data: [[2, 43]]
+                }, {
+                    name: 'two points',
+                    type: 'line',
+                    data: [[2, 43], [4, 99]]
+                }]
+            });
+        </script>
 
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Use auto calculation when axis min/max's value is null

### Fixed issues
Close #11829 

## Details
<img width="289" alt="Screen Shot 2020-03-02 at 11 48 03" src="https://user-images.githubusercontent.com/20318608/75643984-b673da00-5c7b-11ea-97d4-7efae754c64d.png">

### Before: What was the problem?
<img width="378" alt="Screen Shot 2020-03-02 at 11 44 04" src="https://user-images.githubusercontent.com/20318608/75643989-bd025180-5c7b-11ea-9ed3-9c3db839b889.png">


### After: How is it fixed in this PR?
<img width="415" alt="Screen Shot 2020-03-02 at 11 43 39" src="https://user-images.githubusercontent.com/20318608/75644009-d1464e80-5c7b-11ea-82b5-f69b629d6c39.png">



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
