### PR TITLE
fix(map): map animation when zoom and center change. fix #11947

### DIFF
--- a/src/component/helper/MapDraw.js
+++ b/src/component/helper/MapDraw.js
@@ -24,6 +24,7 @@ import {onIrrelevantElement} from '../../component/helper/cursorHelper';
 import * as graphic from '../../util/graphic';
 import geoSourceManager from '../../coord/geo/geoSourceManager';
 import {getUID} from '../../util/component';
+import Transformable from 'zrender/src/mixin/Transformable';
 
 function getFixedItemStyle(model) {
     var itemStyle = model.getItemStyle();
@@ -182,9 +183,25 @@ MapDraw.prototype = {
         var group = this.group;
 
         var transformInfo = geo.getTransformInfo();
-        group.transform = transformInfo.roamTransform;
-        group.decomposeTransform();
-        group.dirty();
+        // No animation when first draw or in action
+        var isFirstDraw = !regionsGroup.childAt(0) || payload;
+        var targetScale;
+        if (isFirstDraw) {
+            group.transform = transformInfo.roamTransform;
+            group.decomposeTransform();
+            group.dirty();
+        }
+        else {
+            var target = new Transformable();
+            target.transform = transformInfo.roamTransform;
+            target.decomposeTransform();
+            var props = {
+                scale: target.scale,
+                position: target.position
+            };
+            targetScale = target.scale;
+            graphic.updateProps(group, props, mapOrGeoModel);
+        }
 
         var scale = transformInfo.rawScale;
         var position = transformInfo.rawPosition;
@@ -325,6 +342,12 @@ MapDraw.prototype = {
                         textVerticalAlign: 'middle'
                     }
                 );
+
+                if (!isFirstDraw) {
+                    // Text animation
+                    var textScale = [1 / targetScale[0], 1 / targetScale[1]];
+                    graphic.updateProps(textEl, { scale: textScale }, mapOrGeoModel);
+                }
 
                 regionGroup.add(textEl);
             }

--- a/test/map.html
+++ b/test/map.html
@@ -34,6 +34,7 @@ under the License.
 
         <div id="main0"></div>
         <div id="main1"></div>
+        <div id="main2"></div>
 
 
 
@@ -382,6 +383,77 @@ under the License.
 
         </script>
 
+
+
+
+
+
+
+
+
+
+
+
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                require(['map/js/china'], function () {
+                    var locations = [{
+                        name: '上海',
+                        coord: [121.472644, 31.231706]
+                    }, {
+                        name: '北京',
+                        coord: [116.405285, 39.904989]
+                    }, {
+                        name: '广东',
+                        coord: [113.280637, 23.839463714285714]
+                    }];
+                    option = {
+                        tooltip: {
+                            trigger: 'item',
+                            formatter: '{b}'
+                        },
+                        series: [
+                            {
+                                name: '中国',
+                                type: 'map',
+                                mapType: 'china',
+                                selectedMode : 'multiple',
+                                label: {
+                                    show: true
+                                }
+                            }
+                        ]
+                    };
+                    var myChart = testHelper.create(echarts, 'main2', {
+                        option: option,
+                        height: 550,
+                        title: ['Animation when changing map zoom and center']
+                    });
+                    var currentLoc = 0;
+                    setInterval(function () {
+                        myChart.setOption({
+                            series: [{
+                                center: locations[currentLoc].coord,
+                                zoom: 4,
+                                data: [
+                                    {name: locations[currentLoc].name, selected: true}
+                                ],
+                                animationDurationUpdate: 1000,
+                                animationEasingUpdate: 'cubicInOut'
+                            }]
+                        });
+                        currentLoc = (currentLoc + 1) % locations.length;
+                    }, 2000);
+
+                });
+
+            });
+
+        </script>
 
 
 


### PR DESCRIPTION
This bug was introduced by 7cc5cb5b2e105fdf75033c5c6c8ef214L195

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Add map animation when zoom and center change.

### Fixed issues


- #11947: Missing animation when changing zoom and center of geo component


## Details

### Before: What was the problem?

No animation.


### After: How is it fixed in this PR?

Use `updateProps` to set animation.



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

test/map.html



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
