### PR TITLE
fix(tree): the symbols of image type do not display at the first rendering. close #12279.

### DIFF
--- a/src/chart/helper/Symbol.js
+++ b/src/chart/helper/Symbol.js
@@ -238,7 +238,7 @@ symbolProto._updateCommon = function (data, idx, symbolSize, seriesScope) {
     }
     else {
         symbolPath.setStyle({
-            opacity: null,
+            opacity: 1,
             shadowBlur: null,
             shadowOffsetX: null,
             shadowOffsetY: null,

--- a/src/chart/tree/TreeView.js
+++ b/src/chart/tree/TreeView.js
@@ -376,9 +376,8 @@ function updateNode(data, dataIndex, symbolEl, group, seriesModel, seriesScope) 
         symbolEl = new SymbolClz(data, dataIndex, seriesScope);
         symbolEl.attr('position', [sourceOldLayout.x, sourceOldLayout.y]);
     }
-    else {
-        symbolEl.updateData(data, dataIndex, seriesScope);
-    }
+
+    symbolEl.updateData(data, dataIndex, seriesScope);
 
     symbolEl.__radialOldRawX = symbolEl.__radialRawX;
     symbolEl.__radialOldRawY = symbolEl.__radialRawY;

--- a/src/chart/tree/TreeView.js
+++ b/src/chart/tree/TreeView.js
@@ -375,9 +375,17 @@ function updateNode(data, dataIndex, symbolEl, group, seriesModel, seriesScope) 
     if (isInit) {
         symbolEl = new SymbolClz(data, dataIndex, seriesScope);
         symbolEl.attr('position', [sourceOldLayout.x, sourceOldLayout.y]);
-    }
 
-    symbolEl.updateData(data, dataIndex, seriesScope);
+        // Fix #12279.
+        // if the type of symbol is image,
+        // update symbol's data immediately but not wait until the next update rendering.
+        var symbolType = symbolEl._symbolType;
+        symbolType.indexOf('image://') === 0 
+            && symbolEl.updateData(data, dataIndex, seriesScope);
+    }
+    else {
+        symbolEl.updateData(data, dataIndex, seriesScope);
+    }
 
     symbolEl.__radialOldRawX = symbolEl.__radialRawX;
     symbolEl.__radialOldRawY = symbolEl.__radialRawY;

--- a/src/chart/tree/TreeView.js
+++ b/src/chart/tree/TreeView.js
@@ -375,12 +375,6 @@ function updateNode(data, dataIndex, symbolEl, group, seriesModel, seriesScope) 
     if (isInit) {
         symbolEl = new SymbolClz(data, dataIndex, seriesScope);
         symbolEl.attr('position', [sourceOldLayout.x, sourceOldLayout.y]);
-
-        // Fix #12279.
-        // if the type of symbol is image,
-        // update symbol's data immediately but not wait until the next update rendering.
-        var symbolType = symbolEl.getSymbolPath().type;
-        symbolType === 'image' && symbolEl.updateData(data, dataIndex, seriesScope);
     }
     else {
         symbolEl.updateData(data, dataIndex, seriesScope);

--- a/src/chart/tree/TreeView.js
+++ b/src/chart/tree/TreeView.js
@@ -379,9 +379,8 @@ function updateNode(data, dataIndex, symbolEl, group, seriesModel, seriesScope) 
         // Fix #12279.
         // if the type of symbol is image,
         // update symbol's data immediately but not wait until the next update rendering.
-        var symbolType = symbolEl._symbolType;
-        symbolType.indexOf('image://') === 0 
-            && symbolEl.updateData(data, dataIndex, seriesScope);
+        var symbolType = symbolEl.getSymbolPath().type;
+        symbolType === 'image' && symbolEl.updateData(data, dataIndex, seriesScope);
     }
     else {
         symbolEl.updateData(data, dataIndex, seriesScope);

--- a/test/tree-image2.html
+++ b/test/tree-image2.html
@@ -1,0 +1,98 @@
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+        <style>
+            #main {
+                height: 600px;
+            }
+            .test-chart {
+                height: 600px;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="main"></div>
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                $.getJSON('./data/tree-simple.json', function (data) {
+
+                    var option = {
+                        tooltip: {
+                            trigger: 'item',
+                            triggerOn: 'mousemove'
+                        },
+                        series:[
+                            {
+                                type: 'tree',
+
+                                data: [data],
+                                roam: true,
+                                top: '2%',
+                                left: '7%',
+                                bottom: '1%',
+                                right: '20%',
+
+                                symbol: 'image://https://github.githubassets.com/images/icons/emoji/electron.png',
+
+                                symbolSize: 10,
+
+                                label: {
+                                    position: 'left',
+                                    verticalAlign: 'middle',
+                                    align: 'right'
+                                },
+
+                                leaves: {
+                                    label: {
+                                        position: 'right',
+                                        verticalAlign: 'middle',
+                                        align: 'left'
+                                    }
+                                },
+
+                                expandAndCollapse: true,
+                                animationDuration: 550,
+                                animationDurationUpdate: 750
+                            }
+                        ]
+                    };
+
+                    var chart = testHelper.create(echarts, 'main', {
+                        title: 'Fix the issue #12279 that symbols with image do not display at the first rendering',
+                        option: option
+                    });
+
+                });
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes #12279
Fixes #11860


### Fixed issues

- #12279
- #11860

## Details

### Before: What was the problem?
The symbols of image type do not display at the first rendering. Please refer to #12279, #11860 for more details.


![Incorrect View](https://user-images.githubusercontent.com/26999792/78205580-11912a80-74cf-11ea-83a7-c40fa4186283.jpg)


### After: How is it fixed in this PR?

![Correct View](https://user-images.githubusercontent.com/26999792/78206752-45218400-74d2-11ea-87fe-abf11b5eff53.png)

After creating the instance of `SymbolClz`, update its data immediately but not wait until the next update rendering if the type of symbol is image.


### Related test cases

Refer to `test/tree-image2.html` for a test case.
