### PR TITLE
fix: Some styles of Tooltip is not working on RichText mode

### DIFF
--- a/src/component/tooltip/TooltipRichContent.js
+++ b/src/component/tooltip/TooltipRichContent.js
@@ -110,9 +110,11 @@ TooltipRichContent.prototype = {
             style: {
                 rich: markers,
                 text: content,
-                textLineHeight: 20,
+                textLineHeight: tooltipModel.get('textStyle.lineHeight'),
                 textBackgroundColor: tooltipModel.get('backgroundColor'),
                 textBorderRadius: tooltipModel.get('borderRadius'),
+                textBorderWidth: tooltipModel.get('borderWidth'),
+                textBorderColor: tooltipModel.get('borderColor'),
                 textFill: tooltipModel.get('textStyle.color'),
                 textPadding: tooltipModel.get('padding')
             },

--- a/test/tooltip-rich.html
+++ b/test/tooltip-rich.html
@@ -61,7 +61,12 @@ under the License.
                         enterable: true,
                         // position: [100, 100],
                         trigger: 'axis',
-                        z: 100
+                        z: 100,
+                        borderColor: '#333',
+                        borderWidth: 1,
+                        textStyle: {
+                            lineHeight: 10
+                        }
                     },
                     yAxis: {
                         type: 'value'


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix the issue #12318

### Fixed issues

<!--
- #xxxx: ...
-->
- #12318

### Related test cases

Test case: refer to test/tooltip-rich.html