### PR TITLE
fix(line): fix line clip bug in chromium

### DIFF
--- a/src/chart/helper/createClipPathFromCoordSys.js
+++ b/src/chart/helper/createClipPathFromCoordSys.js
@@ -35,6 +35,10 @@ function createGridClipPath(cartesian, hasAnimation, seriesModel) {
     width += lineWidth;
     height += lineWidth;
 
+    // fix: https://github.com/apache/incubator-echarts/issues/11369
+    x = Math.floor(x);
+    width = Math.round(width);
+
     var clipPath = new graphic.Rect({
         shape: {
             x: x,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix clip bug in chromium when chart size over 18000px.


### Fixed issues
- [11369](https://github.com/apache/incubator-echarts/issues/11369)


