### PR TITLE
fix(sunburst): lift sunburst with higher z2 on emphasis

### DIFF
--- a/src/chart/sunburst/SunburstPiece.js
+++ b/src/chart/sunburst/SunburstPiece.js
@@ -158,6 +158,8 @@ SunburstPieceProto.updateData = function (
 
     this._seriesModel = seriesModel || this._seriesModel;
     this._ecModel = ecModel || this._ecModel;
+
+    graphic.setHoverStyle(this);
 };
 
 SunburstPieceProto.onEmphasis = function (highlightPolicy) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix sunburst not being lifted with higher z2 when mouse hovers on.

### Fixed issues

Originally reported from https://lists.apache.org/thread.html/r2cd2ec8c9241d87ab2ce2cd472596b4bc31df25d58e5b0a9b66db5ab%40%3Cdev.echarts.apache.org%3E .


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img width="272" alt="屏幕快照 2020-04-20 17 44 37" src="https://user-images.githubusercontent.com/779050/79737963-b2387480-832e-11ea-8de1-8fa598155ceb.png">

Border is not clear owing to the same z2 with other sectors.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="297" alt="屏幕快照 2020-04-20 17 43 59" src="https://user-images.githubusercontent.com/779050/79738032-cb412580-832e-11ea-99b2-ca942bddf2c4.png">

Border is clear.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
