### PR TITLE
Fix: gauge chart legend color is incorrect

### DIFF
--- a/src/chart/gauge/GaugeSeries.js
+++ b/src/chart/gauge/GaugeSeries.js
@@ -92,9 +92,6 @@ var GaugeSeries = SeriesModel.extend({
             length: '80%',
             width: 8
         },
-        itemStyle: {
-            color: 'auto'
-        },
         title: {
             show: true,
             // x, y，单位px

--- a/src/chart/gauge/GaugeView.js
+++ b/src/chart/gauge/GaugeView.js
@@ -342,7 +342,7 @@ var GaugeView = ChartView.extend({
 
             pointer.useStyle(itemModel.getModel('itemStyle').getItemStyle());
 
-            if (pointer.style.fill === 'auto') {
+            if (pointer.style.fill === '#000') {
                 pointer.setStyle('fill', getColor(
                     linearMap(data.get(valueDim, idx), valueExtent, [0, 1], true)
                 ));

--- a/src/chart/gauge/GaugeView.js
+++ b/src/chart/gauge/GaugeView.js
@@ -342,7 +342,8 @@ var GaugeView = ChartView.extend({
 
             pointer.useStyle(itemModel.getModel('itemStyle').getItemStyle());
 
-            if (pointer.style.fill === '#000') {
+            var itemStyleModel = itemModel.getModel('itemStyle');
+            if (pointer.style.fill === '#000' && !itemStyleModel.get('color')) {
                 pointer.setStyle('fill', getColor(
                     linearMap(data.get(valueDim, idx), valueExtent, [0, 1], true)
                 ));

--- a/test/gauge-simple.html
+++ b/test/gauge-simple.html
@@ -47,6 +47,8 @@ under the License.
 
     <div id="main3"></div>
 
+    <div id="main4"></div>
+
 
 
 
@@ -174,6 +176,84 @@ under the License.
             };
 
             var chart = testHelper.create(echarts, 'main3', {
+                title: [
+                    'Simple gauge',
+                    'Legend rect color should be red'
+                ],
+                option: option
+            });
+        });
+    </script>
+
+    <script>
+        require(['echarts'], function (echarts) {
+            option = {
+                tooltip: {
+                    formatter: '{a} <br/>{b} : {c}%'
+                },
+                legend: {
+					backgroundColor: "#ffffff",
+					borderColor: "#662727",
+					align:'right',
+					data: [
+					    {
+					        name:"浙江",
+					        textStyle: {
+        						color:['red']
+        					}
+					    },
+					    {
+					        name:"鞍山",
+					        textStyle: {
+        						color:['green']
+        					}
+					    },
+					    {
+					        name:"沈阳",
+					        textStyle: {
+        						color:['blue']
+        					}
+					    }
+						
+					],
+					show: true,
+					
+				},
+                toolbox: {
+                    feature: {
+                        restore: {},
+                        saveAsImage: {}
+                    }
+                },
+                series: [
+                    {
+                        name: '浙江',
+                        type: 'gauge',
+                        detail: {formatter: '{value}%'},
+                        data: [{value: 50, name: '完成率'}],
+                        center:['20%','50%'],
+                        radius:'20%'
+                    },
+                    {
+                        name: '鞍山',
+                        type: 'gauge',
+                        detail: {formatter: '{value}%'},
+                        data: [{value: 50, name: '完成率'}],
+                        center:['50%','50%'],
+                        radius:'20%'
+                    },
+                    {
+                        name: '沈阳',
+                        type: 'gauge',
+                        detail: {formatter: '{value}%'},
+                        data: [{value: 50, name: '完成率'}],
+                        center:['80%','50%'],
+                        radius:'20%'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main4', {
                 title: [
                     'Simple gauge',
                     'Legend rect color should be red'

--- a/test/gauge-simple.html
+++ b/test/gauge-simple.html
@@ -45,6 +45,7 @@ under the License.
 
     <div id="main2"></div>
 
+    <div id="main3"></div>
 
 
 
@@ -148,6 +149,34 @@ under the License.
             var chart = testHelper.create(echarts, 'main2', {
                 title: [
                     'Gauge with no data, should display NaN'
+                ],
+                option: option
+            });
+        });
+    </script>
+
+    <script>
+        require(['echarts'], function (echarts) {
+            var option = {
+                legend: {
+                    data: ['浙江']
+                    
+                },
+                series: [
+                    {
+                        name: '浙江',
+                        type: 'gauge',
+                        data: [
+                            {value: 10, name: '完成率'}
+                        ]
+                    },
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main3', {
+                title: [
+                    'Simple gauge',
+                    'Legend rect color should be red'
                 ],
                 option: option
             });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Gauge series shouldn't have itemStyle option at default



### Fixed issues

Close #12376 


## Details

### Before: What was the problem?

![Screen Shot 2020-04-21 at 10 55 35](https://user-images.githubusercontent.com/20318608/79820475-e3608580-83be-11ea-873e-070347e0ff66.png)




### After: How is it fixed in this PR?

![Screen Shot 2020-04-21 at 10 55 52](https://user-images.githubusercontent.com/20318608/79820485-e9eefd00-83be-11ea-8b0a-24d159ac01b1.png)




## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
