### PR TITLE
feat(dataZoom): custom brush style in toolbox.feature.dataZoom

### DIFF
--- a/src/component/toolbox/feature/DataZoom.js
+++ b/src/component/toolbox/feature/DataZoom.js
@@ -61,7 +61,11 @@ DataZoom.defaultOption = {
         back: 'M22,1.4L9.9,13.5l12.3,12.3 M10.3,13.5H54.9v44.6 H10.3v-26'
     },
     // `zoom`, `back`
-    title: zrUtil.clone(dataZoomLang.title)
+    title: zrUtil.clone(dataZoomLang.title),
+    brushStyle: {
+        borderWidth: 0,
+        color: 'rgba(0,0,0,0.2)'
+    }
 };
 
 var proto = DataZoom.prototype;
@@ -236,14 +240,28 @@ function updateZoomBtnStatus(featureModel, ecModel, view, payload, api) {
             zoomActive
             ? {
                 brushType: 'auto',
-                brushStyle: {
-                    // FIXME user customized?
-                    lineWidth: 0,
-                    fill: 'rgba(0,0,0,0.2)'
-                }
+                brushStyle: mapBrushStyle(featureModel.option.brushStyle)
             }
             : false
         );
+}
+
+function mapBrushStyle(brushStyle) {
+    var properties = [
+        ['fill', 'color'],
+        ['lineWidth', 'borderWidth'],
+        ['stroke', 'borderColor'],
+        ['opacity', 'opacity']
+    ];
+    var style = {};
+    for (var i = 0; i < properties.length; i++) {
+        var propName = properties[i][1];
+        var val = brushStyle[propName];
+        if (val != null) {
+            style[properties[i][0]] = val;
+        }
+    }
+    return style;
 }
 
 

--- a/src/component/toolbox/feature/DataZoom.js
+++ b/src/component/toolbox/feature/DataZoom.js
@@ -240,28 +240,10 @@ function updateZoomBtnStatus(featureModel, ecModel, view, payload, api) {
             zoomActive
             ? {
                 brushType: 'auto',
-                brushStyle: mapBrushStyle(featureModel.option.brushStyle)
+                brushStyle: featureModel.getModel('brushStyle').getItemStyle()
             }
             : false
         );
-}
-
-function mapBrushStyle(brushStyle) {
-    var properties = [
-        ['fill', 'color'],
-        ['lineWidth', 'borderWidth'],
-        ['stroke', 'borderColor'],
-        ['opacity', 'opacity']
-    ];
-    var style = {};
-    for (var i = 0; i < properties.length; i++) {
-        var propName = properties[i][1];
-        var val = brushStyle[propName];
-        if (val != null) {
-            style[properties[i][0]] = val;
-        }
-    }
-    return style;
 }
 
 

--- a/test/dataZoom-toolbox.html
+++ b/test/dataZoom-toolbox.html
@@ -145,7 +145,13 @@ under the License.
                         dataView: {},
                         dataZoom: {
                             show: true,
-                            yAxisIndex: null
+                            yAxisIndex: null,
+                            // brushStyle: {
+                            //     borderWidth: 2,
+                            //     color: 'blue',
+                            //     opacity: 0.1,
+                            //     borderColor: '#596A76',
+                            // }
                         },
                         restore: {show: true},
                         saveAsImage: {}


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

allow user to custom brush style in toolbox.feature.dataZoom

### Fixed issues

<!--
- #xxxx: ...
-->

#8964

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

框选型数据区域缩放组件不能更改选框颜色，在暗色主题下表现不好

### After: How is it fixed in this PR?

允许用户通过配置自定义选框样式

       toolbox: {
            feature: {
                dataZoom: {
                    show: true,
                    yAxisIndex: null,
                    brushStyle: {
                        borderWidth: 2,
                        color: 'blue',
                        opacity: 0.1,
                        borderColor: '#596A76',
                     }
                },
            }
        },
<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
