### PR TITLE
saveAsImage function, use document.defaultView instead of window

### DIFF
--- a/src/component/toolbox/feature/SaveAsImage.js
+++ b/src/component/toolbox/feature/SaveAsImage.js
@@ -67,7 +67,8 @@ proto.onclick = function (ecModel, api) {
         $a.target = '_blank';
         $a.href = url;
         var evt = new MouseEvent('click', {
-            view: window,
+            // some micro front-end framework， window maybe is a Proxy
+            view: document.defaultView,
             bubbles: true,
             cancelable: false
         });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [✅ ] others



### What does this PR do?

in some micro front-end framework( for examle taobao's qiankun framework), window maybe is a Proxy ,so use document.defaultView instead of it , to solve the saveAsImage error.


### Fixed issues
before:
![image](https://user-images.githubusercontent.com/15673574/82051124-e6177780-96eb-11ea-8a97-eb23c87485c2.png)

after:
![image](https://user-images.githubusercontent.com/15673574/82051188-ffb8bf00-96eb-11ea-9650-04dd70152443.png)



