### PR TITLE
feat: provide elapsed time in rendered event

### DIFF
--- a/src/echarts.ts
+++ b/src/echarts.ts
@@ -1566,9 +1566,9 @@ class ECharts extends Eventful {
          * (5) no delayed setOption needs to be processed.
          */
         bindRenderedEvent = function (zr: zrender.ZRenderType, ecIns: ECharts): void {
-            zr.on('rendered', function () {
+            zr.on('rendered', function (params) {
 
-                ecIns.trigger('rendered');
+                ecIns.trigger('rendered', params);
 
                 // The `finished` event should not be triggered repeatly,
                 // so it should only be triggered when rendering indeed happend


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Provide elapsed time in rendered event.

Usage:

```
chart.on('rendered', function (params) {
    console.log(params.elapsedTime);
});
```

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Developers find it hard to know how long does it take for each frame when debugging.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Providing `elapsedTime` of each frame in `rendered` event.

## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

Added `params`:

```
chart.on('rendered', function (params) {
    console.log(params.elapsedTime);
});
```

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information

Relies on https://github.com/ecomfe/zrender/pull/570 . Merge after the PR in zrender is merged.
