### PR TITLE
fix(radar): symbolRotate does not work for radar series.

### DIFF
--- a/src/chart/radar/RadarView.js
+++ b/src/chart/radar/RadarView.js
@@ -52,12 +52,14 @@ export default echarts.extendChartView({
             var symbolPath = symbolUtil.createSymbol(
                 symbolType, -1, -1, 2, 2, color
             );
+            var symbolRotate = data.getItemVisual(idx, 'symbolRotate') || 0;
             symbolPath.attr({
                 style: {
                     strokeNoScale: true
                 },
                 z2: 100,
-                scale: [symbolSize[0] / 2, symbolSize[1] / 2]
+                scale: [symbolSize[0] / 2, symbolSize[1] / 2],
+                rotation: symbolRotate * Math.PI / 180 || 0
             });
             return symbolPath;
         }

--- a/test/radar.html
+++ b/test/radar.html
@@ -90,7 +90,12 @@ under the License.
                                 value: ['-', 8000, 20000, 20000, 40000, 10000],
                                 name: '第一个元素是 null'
                             }
-                        ]
+                        ],
+                        symbol: 'triangle',
+                        symbolSize: 20,
+                        symbolRotate: function(value, params) {
+                            return ~~(360 * Math.random());
+                        }
                     }]
                 });
                 var theIndex = 2;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes the bug that `symbolRotate` does not work for `radar` series.

## Details

### Before: What was the problem?

Whatever we set `symbolRotate`, symbol of radar is always facing north.

![image](https://user-images.githubusercontent.com/26999792/82809991-f5eb4480-9ebf-11ea-8f02-5115c747a93e.png)

### After: How is it fixed in this PR?

symbol of radar will perform a rotation as we specify.

![image](https://user-images.githubusercontent.com/26999792/82810109-3b0f7680-9ec0-11ea-8a05-a88da1b524e7.png)


## Usage

### Related test cases or examples to use the new APIs

Please refer to `test/radar.html`.
