### PR TITLE
fix(markPoint): symbolRotate for markPoint does not work.

### DIFF
--- a/src/component/marker/MarkPointView.js
+++ b/src/component/marker/MarkPointView.js
@@ -104,10 +104,12 @@ export default MarkerView.extend({
             var itemModel = mpData.getItemModel(idx);
             var symbol = itemModel.getShallow('symbol');
             var symbolSize = itemModel.getShallow('symbolSize');
+            var symbolRotate = itemModel.getShallow('symbolRotate');
             var isFnSymbol = zrUtil.isFunction(symbol);
             var isFnSymbolSize = zrUtil.isFunction(symbolSize);
+            var isFnSymbolRotate = zrUtil.isFunction(symbolRotate);
 
-            if (isFnSymbol || isFnSymbolSize) {
+            if (isFnSymbol || isFnSymbolSize || isFnSymbolRotate) {
                 var rawIdx = mpModel.getRawValue(idx);
                 var dataParams = mpModel.getDataParams(idx);
                 if (isFnSymbol) {
@@ -117,11 +119,15 @@ export default MarkerView.extend({
                     // FIXME 这里不兼容 ECharts 2.x，2.x 貌似参数是整个数据？
                     symbolSize = symbolSize(rawIdx, dataParams);
                 }
+                if (isFnSymbolRotate) {
+                    symbolRotate = symbolRotate(rawIdx, dataParams);
+                }
             }
 
             mpData.setItemVisual(idx, {
                 symbol: symbol,
                 symbolSize: symbolSize,
+                symbolRotate: symbolRotate,
                 color: itemModel.get('itemStyle.color')
                     || seriesData.getVisual('color')
             });

--- a/test/markPoint.html
+++ b/test/markPoint.html
@@ -144,9 +144,14 @@ under the License.
                                     {
                                         name: '平均值stack',
                                         type: 'average',
-                                        value: 1
+                                        value: 1,
+                                        // 覆盖series配置的symbolRotate
+                                        symbolRotate: 45
                                     }
-                                ]
+                                ],
+                                symbolRotate: function(value, params) {
+                                    return ~~(Math.random() * 360);
+                                }
                             }
                         },
                         {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes #12731 `symbolRotate` for `markPoint` does not work

### Fixed issues

- #12731

## Details

### Before: What was the problem?

Symbols don't rotate even if we've specified `symbolRotate`.

![image](https://user-images.githubusercontent.com/26999792/83527450-662a4380-a51a-11ea-9d86-dca75b6765e1.png)


### After: How is it fixed in this PR?

Symbols will perform the rotation as we specified.

![image](https://user-images.githubusercontent.com/26999792/83527687-b30e1a00-a51a-11ea-8cca-beec838704dc.png)



## Usage

### Related test cases or examples to use the new APIs

Please refer to `test/markPoint.html`.
