### PR TITLE
fix(sunburst): enables label formatter in levels #12223

### DIFF
--- a/src/chart/sunburst/SunburstPiece.js
+++ b/src/chart/sunburst/SunburstPiece.js
@@ -203,9 +203,13 @@ SunburstPieceProto._updateLabel = function (seriesModel, visualColor, state) {
         : itemModel.getModel(state + '.label');
     var labelHoverModel = itemModel.getModel('emphasis.label');
 
+    var labelFormatter = labelModel.get('formatter');
+    // Use normal formatter if no state formatter is defined
+    var labelState = labelFormatter ? state : 'normal';
+
     var text = zrUtil.retrieve(
         seriesModel.getFormattedLabel(
-            this.node.dataIndex, state, null, null, 'label'
+            this.node.dataIndex, labelState, null, null, 'label'
         ),
         this.node.name
     );

--- a/src/chart/sunburst/SunburstSeries.js
+++ b/src/chart/sunburst/SunburstSeries.js
@@ -38,22 +38,14 @@ export default SeriesModel.extend({
 
         completeTreeValue(root);
 
-        var levels = option.levels || [];
-
-        // levels = option.levels = setDefault(levels, ecModel);
-
-        var levelModels = zrUtil.map(levels || [], function (levelDefine) {
+        var levelModels = zrUtil.map(option.levels || [], function (levelDefine) {
             return new Model(levelDefine, this, ecModel);
         }, this);
-
-        var treeOption = {};
-
-        treeOption.levels = levels;
 
         // Make sure always a new tree is created when setOption,
         // in TreemapView, we check whether oldTree === newTree
         // to choose mappings approach among old shapes and new shapes.
-        var tree = Tree.createTree(root, this, treeOption, beforeLink);
+        var tree = Tree.createTree(root, this, beforeLink);
 
         function beforeLink(nodeData) {
             nodeData.wrapMethod('getItemModel', function (model, idx) {

--- a/src/chart/tree/TreeSeries.js
+++ b/src/chart/tree/TreeSeries.js
@@ -45,7 +45,7 @@ export default SeriesModel.extend({
         var leaves = option.leaves || {};
         var leavesModel = new Model(leaves, this, this.ecModel);
 
-        var tree = Tree.createTree(root, this, {}, beforeLink);
+        var tree = Tree.createTree(root, this, beforeLink);
 
         function beforeLink(nodeData) {
             nodeData.wrapMethod('getItemModel', function (model, idx) {

--- a/src/chart/treemap/TreemapSeries.js
+++ b/src/chart/treemap/TreemapSeries.js
@@ -190,7 +190,7 @@ export default SeriesModel.extend({
         // Make sure always a new tree is created when setOption,
         // in TreemapView, we check whether oldTree === newTree
         // to choose mappings approach among old shapes and new shapes.
-        var tree = Tree.createTree(root, this, null, beforeLink);
+        var tree = Tree.createTree(root, this, beforeLink);
 
         function beforeLink(nodeData) {
             nodeData.wrapMethod('getItemModel', function (model, idx) {

--- a/src/chart/treemap/treemapVisual.js
+++ b/src/chart/treemap/treemapVisual.js
@@ -36,14 +36,9 @@ export default {
             return;
         }
 
-        var levelItemStyles = zrUtil.map(tree.levelModels, function (levelModel) {
-            return levelModel ? levelModel.get(ITEM_STYLE_NORMAL) : null;
-        });
-
         travelTree(
             root, // Visual should calculate from tree root but not view root.
             {},
-            levelItemStyles,
             seriesItemStyleModel,
             seriesModel.getViewRoot().getAncestors(),
             seriesModel
@@ -52,7 +47,7 @@ export default {
 };
 
 function travelTree(
-    node, designatedVisual, levelItemStyles, seriesItemStyleModel,
+    node, designatedVisual, seriesItemStyleModel,
     viewRootAncestors, seriesModel
 ) {
     var nodeModel = node.getModel();
@@ -64,9 +59,8 @@ function travelTree(
     }
 
     var nodeItemStyleModel = node.getModel(ITEM_STYLE_NORMAL);
-    var levelItemStyle = levelItemStyles[node.depth];
     var visuals = buildVisuals(
-        nodeItemStyleModel, designatedVisual, levelItemStyle, seriesItemStyleModel
+        nodeItemStyleModel, designatedVisual, seriesItemStyleModel
     );
 
     // calculate border color
@@ -101,7 +95,7 @@ function travelTree(
                     nodeModel, visuals, child, index, mapping, seriesModel
                 );
                 travelTree(
-                    child, childVisual, levelItemStyles, seriesItemStyleModel,
+                    child, childVisual, seriesItemStyleModel,
                     viewRootAncestors, seriesModel
                 );
             }
@@ -110,14 +104,13 @@ function travelTree(
 }
 
 function buildVisuals(
-    nodeItemStyleModel, designatedVisual, levelItemStyle, seriesItemStyleModel
+    nodeItemStyleModel, designatedVisual, seriesItemStyleModel
 ) {
     var visuals = zrUtil.extend({}, designatedVisual);
 
     zrUtil.each(['color', 'colorAlpha', 'colorSaturation'], function (visualName) {
         // Priority: thisNode > thisLevel > parentNodeDesignated > seriesModel
         var val = nodeItemStyleModel.get(visualName, true); // Ignore parent
-        val == null && levelItemStyle && (val = levelItemStyle[visualName]);
         val == null && (val = designatedVisual[visualName]);
         val == null && (val = seriesItemStyleModel.get(visualName));
 

--- a/src/data/Tree.js
+++ b/src/data/Tree.js
@@ -24,7 +24,6 @@
  */
 
 import * as zrUtil from 'zrender/src/core/util';
-import Model from '../model/Model';
 import linkList from './helper/linkList';
 import List from './List';
 import createDimensions from './helper/createDimensions';
@@ -247,22 +246,7 @@ TreeNode.prototype = {
         }
         var hostTree = this.hostTree;
         var itemModel = hostTree.data.getItemModel(this.dataIndex);
-        var levelModel = this.getLevelModel();
-
-        // FIXME: refactor levelModel to "beforeLink", and remove levelModel here.
-        if (levelModel) {
-            return itemModel.getModel(path, levelModel.getModel(path));
-        }
-        else {
-            return itemModel.getModel(path);
-        }
-    },
-
-    /**
-     * @return {module:echarts/model/Model}
-     */
-    getLevelModel: function () {
-        return (this.hostTree.levelModels || [])[this.depth];
+        return itemModel.getModel(path);
     },
 
     /**
@@ -334,9 +318,8 @@ TreeNode.prototype = {
  * @constructor
  * @alias module:echarts/data/Tree
  * @param {module:echarts/model/Model} hostModel
- * @param {Array.<Object>} levelOptions
  */
-function Tree(hostModel, levelOptions) {
+function Tree(hostModel) {
     /**
      * @type {module:echarts/data/Tree~TreeNode}
      * @readOnly
@@ -362,15 +345,6 @@ function Tree(hostModel, levelOptions) {
      * @type {module:echarts/model/Model}
      */
     this.hostModel = hostModel;
-
-    /**
-     * @private
-     * @readOnly
-     * @type {Array.<module:echarts/model/Model}
-     */
-    this.levelModels = zrUtil.map(levelOptions || [], function (levelDefine) {
-        return new Model(levelDefine, hostModel, hostModel.ecModel);
-    });
 
 }
 
@@ -461,13 +435,11 @@ Tree.prototype = {
  * @static
  * @param {Object} dataRoot Root node.
  * @param {module:echarts/model/Model} hostModel
- * @param {Object} treeOptions
- * @param {Array.<Object>} treeOptions.levels
  * @return module:echarts/data/Tree
  */
-Tree.createTree = function (dataRoot, hostModel, treeOptions, beforeLink) {
+Tree.createTree = function (dataRoot, hostModel, beforeLink) {
 
-    var tree = new Tree(hostModel, treeOptions && treeOptions.levels);
+    var tree = new Tree(hostModel);
     var listData = [];
     var dimMax = 1;
 

--- a/test/sunburst-visualMap.html
+++ b/test/sunburst-visualMap.html
@@ -128,7 +128,29 @@ under the License.
                         radius: [0, '90%'],
                         label: {
                             rotate: 'radial'
-                        }
+                        },
+                        levels: [{}, {
+                            label: {
+                                formatter: function (params) {
+                                    return 'First Level\n' + params.name;
+                                }
+                            },
+                            emphasis: {
+                                label: {
+                                    formatter: function (params) {
+                                        return 'emphasis\n' + params.name;
+                                    }
+                                }
+                            }
+                        }, {
+                            downplay: {
+                                label: {
+                                    formatter: function (params) {
+                                        return 'downplay\n' + params.name;
+                                    }
+                                }
+                            }
+                        }]
                     }
                 });
 

--- a/test/treemap-simple2.html
+++ b/test/treemap-simple2.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+
+
+
+        <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+            var option;
+
+            option = {
+                series: [
+                    {
+                        name:'treemap',
+                        type:'treemap',
+                        label: {
+                            position: 'insideRight'
+                        },
+                        breadcrumb: {
+                        },
+                        itemStyle: {
+                            color: 'blue'
+                        },
+                        levels: [{
+                            itemStyle: {
+                                borderWidth: 15,
+                                gapWidth: 30,
+                                borderColor: 'pink'
+                            }
+                        }, {
+                            itemStyle: {
+                                borderWidth: 15,
+                                gapWidth: 40,
+                                borderColor: '#333'
+                            }
+                        }, {
+                            itemStyle: {
+                                color: 'green',
+                                borderWidth: 10,
+                                borderColor: '#555570'
+                            }
+                        }],
+                        data:[{
+                            name: '三星',
+                            value: 2,
+                        }, {
+                            name: '小米',
+                            value: 4,
+                            children: [{
+                                name: '小米0',
+                                value: 10,
+                                children: [{
+                                    itemStyle: {
+                                        color: 'orange'
+                                    },
+                                    name: '小尺',
+                                    value: 300
+                                }, {
+                                    name: '小寸',
+                                    value: 200
+                                }, {
+                                    name: '小光年',
+                                    value: 200
+                                }]
+                            }, {
+                                name: '小米1',
+                                value: 4
+                            }]
+                        }, {
+                            name: '三曰生',
+                            value: 1
+                        }]
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Test priority of visual:',
+                    'bg of "小米1" are **green** (in level2 and levels[2].color: "green")',
+                    'bg of "小寸" "小光年" are **green** (in level3 and use designate visual)',
+                    'bg of "小尺" are **orange** (data itemStyle.color: "orange")',
+                    'bg of "三星" "三曰生" are **blue** (in level1, series.itemStyle.color: "blue")',
+                ],
+                option: option,
+                height: 500
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Sunburst labels didn't support formatters in `levels`. This PR enables them.

### Fixed issues

- #12223: 旭日图 levels层级标签formatter不生效

## Details

### Before: What was the problem?

`label.formatter` under `levels` has no effect.

### After: How is it fixed in this PR?

`label.formatter` under `levels` takes effect.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
