### PR TITLE
fix(axisPointer): some properties of label in axisPointer are not working, fix #12642.

### DIFF
--- a/src/component/axisPointer/axisTrigger.js
+++ b/src/component/axisPointer/axisTrigger.js
@@ -286,8 +286,8 @@ function showTooltip(dataByCoordSys, axisInfo, payloadInfo, value) {
         // here. Considering axisPointerModel used here is volatile, which is hard
         // to be retrieve in TooltipView, we prepare parameters here.
         valueLabelOpt: {
-            precision: axisPointerModel.get('label.precision'),
-            formatter: axisPointerModel.get('label.formatter')
+            precision: axisPointerModel.get('label.precision', true),
+            formatter: axisPointerModel.get('label.formatter', true)
         },
         seriesDataIndices: payloadBatch.slice()
     });

--- a/src/component/axisPointer/viewHelper.js
+++ b/src/component/axisPointer/viewHelper.js
@@ -128,7 +128,7 @@ export function getValueLabel(value, axis, ecModel, seriesDataIndices, opt) {
         });
 
         if (zrUtil.isString(formatter)) {
-            text = formatter.replace(/{value}/g, text);
+            text = formatter.replace('{value}', text);
         }
         else if (zrUtil.isFunction(formatter)) {
             text = formatter(params);

--- a/test/tooltip-axisPointer2.html
+++ b/test/tooltip-axisPointer2.html
@@ -1203,11 +1203,11 @@ under the License.
                                 shadowOffsetY: 10,
                                 lineHeight: 20,
                                 color: 'blue',
-                                fontFamily: 'Courier New',
                                 rich: {
                                     name: {
                                         textBorderColor: 'cyan',
                                         fontSize: 16,
+                                        fontFamily: 'Courier New',
                                         //verticalAlign: 'bottom'
                                     },
                                     name2: {
@@ -1215,7 +1215,7 @@ under the License.
                                     }
                                 },
                                 rotate: 10,
-                                formatter: '{name|{value}}\n{name2|{value}111}',
+                                formatter: '{name|{value}}',
                                 width: 50,
                                 height: 40,
                                 //opacity: 0.5

--- a/test/tooltip-axisPointer2.html
+++ b/test/tooltip-axisPointer2.html
@@ -38,7 +38,7 @@ under the License.
 
         <div id="main0"></div>
         <div id="main1"></div>
-
+        <div id="main2"></div>
 
         <script>
 
@@ -1167,7 +1167,91 @@ under the License.
 
         </script>
 
+        <script>
 
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                var option = {
+                    tooltip: {
+                        trigger: 'axis',
+                        padding: 12,
+                        axisPointer: {
+                            type: 'cross',
+                            label: {
+                                //show: false,
+                                fontWeight: 'bold',
+                                precision: 2,
+                                fontSize: 12,
+                                align: 'center',
+                                verticalAlign: 'middle',
+                                textShadowBlur: 10,
+                                textShadowOffsetX: 10,
+                                textShadowOffsetY: 10,
+                                textShadowColor: 'red',
+                                textBorderColor: 'blue',
+                                textBorderWidth: 1,
+                                borderWidth: 1,
+                                borderColor: 'cyan',
+                                borderRadius: 20,
+                                backgroundColor: 'yellow',
+                                padding: 10,
+                                shadowColor: 'green',
+                                shadowBlur: 5,
+                                shadowOffsetX: 10,
+                                shadowOffsetY: 10,
+                                lineHeight: 20,
+                                color: 'blue',
+                                fontFamily: 'Courier New',
+                                rich: {
+                                    name: {
+                                        textBorderColor: 'cyan',
+                                        fontSize: 16,
+                                        //verticalAlign: 'bottom'
+                                    },
+                                    name2: {
+                                        color: 'red'
+                                    }
+                                },
+                                rotate: 10,
+                                formatter: '{name|{value}}\n{name2|{value}111}',
+                                width: 50,
+                                height: 40,
+                                //opacity: 0.5
+                            }
+                        }
+                    },
+                    xAxis: {
+                        data: [
+                            '2020-01-05\n2020-02-05',
+                            '2020-01-06\n2020-02-06',
+                            '2020-01-07\n2020-02-07',
+                            '2020-01-08\n2020-02-08'
+                        ]
+                    },
+                    yAxis: {},
+                    series: [{
+                        type: 'line',
+                        data: [220, 182, 191, 260]
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'More label properties(opacity/rotate/lineHeight/textBorderColor etc.) should be valid',
+                        'Support for rich label',
+                    ],
+                    option: option,
+                    width: 800,
+                    height: 400
+                });
+
+                window.echarts = echarts
+
+            });
+
+        </script>
 
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

- fixes #12642, tweaks #12673  (`lineHeight` does not work)
- added more supported properties of label (`opacity`, `rotate`, `borderRadius`).
- added support for rich label.
- fixes the bug that `formatter` in `axisPointer.label` will affect `formatter` in `tooltip`.

### Fixed issues

- #12642 

## Details

### Before: What was the problem?

- Some properties are invalid, such as `width`, `height`, `textShadowColor`, `textBorderColor`, `textBorderWidth`.
- Rich label is not supported yet.

### After: How is it fixed in this PR?

![image](https://user-images.githubusercontent.com/26999792/83865585-f81f8f80-a758-11ea-83e4-11024444af61.png)



## Usage

### Are there any API changes?

- [x] The API has been changed.

Added `opacity`, `rotate`, `borderRadius`, `rich` properties


### Related test cases or examples to use the new APIs

Please refer to `test/tooltip-axisPointer2.html`.


## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information

A known issue is that it's invalid to set `width` or `height` to a percent string in `rich`.