### PR TITLE
fix(bmap): removed ES5 in bmap extension.

### DIFF
--- a/extension-src/bmap/BMapView.js
+++ b/extension-src/bmap/BMapView.js
@@ -19,6 +19,15 @@
 
 import * as echarts from 'echarts';
 
+function isEmptyObject(obj) {
+    for (var key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 export default echarts.extendComponentView({
     type: 'bmap',
 
@@ -95,7 +104,7 @@ export default echarts.extendComponentView({
         var mapStyleStr = JSON.stringify(newMapStyle);
         if (JSON.stringify(originalStyle) !== mapStyleStr) {
             // FIXME May have blank tile when dragging if setMapStyle
-            if (Object.keys(newMapStyle).length) {
+            if (!isEmptyObject(newMapStyle2)) {
                 bmap.setMapStyle(echarts.util.clone(newMapStyle));
             }
             bMapModel.__mapStyle = JSON.parse(mapStyleStr);
@@ -109,7 +118,7 @@ export default echarts.extendComponentView({
         var mapStyleStr2 = JSON.stringify(newMapStyle2);
         if (JSON.stringify(originalStyle2) !== mapStyleStr2) {
             // FIXME May have blank tile when dragging if setMapStyle
-            if (Object.keys(newMapStyle2).length) {
+            if (!isEmptyObject(newMapStyle2)) {
                 bmap.setMapStyleV2(echarts.util.clone(newMapStyle2));
             }
             bMapModel.__mapStyle2 = JSON.parse(mapStyleStr2);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

According to [Coding Standard](https://echarts.apache.org/en/coding-standard.html#language-features), ES5 shouldn't be used. This PR removed related usage.

## Details

### Before: What was the problem?

`Object.keys` which belongs to ES5 is used in source code.

![image](https://user-images.githubusercontent.com/26999792/84132905-029f9900-aa79-11ea-83da-be27c723ad43.png)


### After: How is it fixed in this PR?

Added a function named `isEmptyObject` as the substitution for `Object.keys`
```js
function isEmptyObject(obj) {
    for (var key in obj) {
        if (obj.hasOwnProperty(key)) {
            return false;
        }
    }
    return true;
}
```

![image](https://user-images.githubusercontent.com/26999792/84133555-e18b7800-aa79-11ea-8bab-f6ad0d445d0a.png)


## Usage

### Are there any API changes?

- [x] The API has been changed.
