### PR TITLE
fix(tooltip): tooltip should be hidden when mouse leaves tooltip content even if it is enterable, fix #12778.

### DIFF
--- a/src/component/tooltip/TooltipContent.js
+++ b/src/component/tooltip/TooltipContent.js
@@ -218,12 +218,15 @@ function TooltipContent(container, api, opt) {
         }
     };
     el.onmouseleave = function () {
+        // fix #12778
+        // we should set `_inContent` before `hideLater`
+        self._inContent = false;
+
         if (self._enterable) {
             if (self._show) {
                 self.hideLater(self._hideDelay);
             }
         }
-        self._inContent = false;
     };
 }
 

--- a/test/tooltip-enterable.html
+++ b/test/tooltip-enterable.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            .test-title {
+                background: #146402;
+                color: #fff;
+            }
+            .test-chart {
+                margin: 0 auto;
+            }
+        </style>
+
+
+        <div id="main0"></div>
+
+
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                var option = {
+                    tooltip: {
+                        trigger: 'item',
+                        formatter: '<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-向左或向右水平移动鼠标<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-向左或向右水平移动鼠标<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<向左或向右水平移动鼠标<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-<-',
+                        enterable: true,
+                        position: ['-30%', '50%']
+                    },
+                    series: [{
+                        name: '访问来源',
+                        type: 'pie',
+                        label: {
+                            show: false,
+                            position: 'center',
+                            color: '#fff'
+                        },
+                        emphasis: {
+                            label: {
+                                show: true,
+                                fontSize: 30,
+                                fontWeight: 'bold'
+                            }
+                        },
+                        labelLine: {
+                            show: false,
+                        },
+                        data: [{
+                            value: 335,
+                            name: '直接访问'
+                        }, {
+                            value: 200,
+                            name: '微博访问'
+                        }]
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main0', {
+                    width: 400,
+                    title: 'Tooltip should be hidden when mouse leaves the tooltip content even if it is enterable',
+                    option: option
+                });
+            });
+
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes #12778 

### Fixed issues

- #12778


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
When `enterable` is `true`, tooltip isn't hidden when mouse leaves tooltip content.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![wrong](https://user-images.githubusercontent.com/26999792/84140783-bb1f0a00-aa84-11ea-9226-aee78e9c603e.gif)

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
We should set `_inContent` to `false` before `hideLater`, please refer to `hideLater` for more infomation.

![image](https://user-images.githubusercontent.com/26999792/84140898-e4d83100-aa84-11ea-92f8-a5cc08a4263b.png)

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
**Expected result**

![right](https://user-images.githubusercontent.com/26999792/84140942-f6b9d400-aa84-11ea-9de8-92171a008ec6.gif)



## Usage

### Are there any API changes?

- [ ] The API has been changed.


### Related test cases

Refer to `test/tooltip-enterable.html`

