### PR TITLE
Update comments to not use defualt (fixing typo)

### DIFF
--- a/src/chart/bar/PictorialBarSeries.js
+++ b/src/chart/bar/PictorialBarSeries.js
@@ -33,7 +33,7 @@ var PictorialBarSeries = BaseBarSeries.extend({
         symbolPosition: null, // 'start' or 'end' or 'center', null means auto.
         symbolOffset: null,
         symbolMargin: null,   // start margin and end margin. Can be a number or a percent string.
-                                // Auto margin by defualt.
+                                // Auto margin by default.
         symbolRepeat: false,  // false/null/undefined, means no repeat.
                                 // Can be true, means auto calculate repeat times and cut by data.
                                 // Can be a number, specifies repeat times, and do not cut by data.

--- a/src/chart/treemap/treemapLayout.js
+++ b/src/chart/treemap/treemapLayout.js
@@ -474,7 +474,7 @@ function position(row, rowFixedLength, rect, halfGapWidth, flush) {
     rect[wh[idx1WhenH]] -= rowOtherLength;
 }
 
-// Return [containerWidth, containerHeight] as defualt.
+// Return [containerWidth, containerHeight] as default.
 function estimateRootSize(seriesModel, targetInfo, viewRoot, containerWidth, containerHeight) {
     // If targetInfo.node exists, we zoom to the node,
     // so estimate whold width and heigth by target node.

--- a/src/component/axisPointer/axisTrigger.js
+++ b/src/component/axisPointer/axisTrigger.js
@@ -163,7 +163,7 @@ function processOnAxis(axisInfo, newValue, updaters, dontSnap, outputFinder) {
     var snapToValue = payloadInfo.snapToValue;
 
     // Fill content of event obj for echarts.connect.
-    // By defualt use the first involved series data as a sample to connect.
+    // By default use the first involved series data as a sample to connect.
     if (payloadBatch[0] && outputFinder.seriesIndex == null) {
         zrUtil.extend(outputFinder, payloadBatch[0]);
     }

--- a/src/component/legend/ScrollableLegendView.js
+++ b/src/component/legend/ScrollableLegendView.js
@@ -471,7 +471,7 @@ var ScrollableLegendView = LegendView.extend({
             var legendDataIdx = child.__legendDataIndex;
             // FIXME
             // If the given targetDataIndex (from model) is illegal,
-            // we use defualtIndex. But the index on the legend model and
+            // we use defaultIndex. But the index on the legend model and
             // action payload is still illegal. That case will not be
             // changed until some scenario requires.
             if (defaultIndex == null && legendDataIdx != null) {

--- a/src/component/visualMap/VisualMapModel.js
+++ b/src/component/visualMap/VisualMapModel.js
@@ -395,7 +395,7 @@ var VisualMapModel = echarts.extendComponentModel({
             // Originally we use visualMap.color as the default color, but setOption at
             // the second time the default color will be erased. So we change to use
             // constant DEFAULT_COLOR.
-            // If user do not want the defualt color, set inRange: {color: null}.
+            // If user do not want the default color, set inRange: {color: null}.
             base.inRange = base.inRange || {color: ecModel.get('gradientColor')};
 
             // If using shortcut like: {inRange: 'symbol'}, complete default value.

--- a/src/coord/axisDefault.js
+++ b/src/coord/axisDefault.js
@@ -30,7 +30,7 @@ var defaultOption = {
     name: '',
     // 'start' | 'middle' | 'end'
     nameLocation: 'end',
-    // By degree. By defualt auto rotate by nameLocation.
+    // By degree. By default auto rotate by nameLocation.
     nameRotate: null,
     nameTruncate: {
         maxWidth: null,

--- a/src/data/List.js
+++ b/src/data/List.js
@@ -406,7 +406,7 @@ listProto.mapDimension = function (coordDim, idx) {
  * Initialize from data
  * @param {Array.<Object|number|Array>} data source or data or data provider.
  * @param {Array.<string>} [nameLIst] The name of a datum is used on data diff and
- *        defualt label/tooltip.
+ *        default label/tooltip.
  *        A name can be specified in encode.itemName,
  *        or dataItem.name (only for series option data),
  *        or provided in nameList from outside.

--- a/src/visual/VisualMapping.js
+++ b/src/visual/VisualMapping.js
@@ -49,7 +49,7 @@ var CATEGORY_DEFAULT_VISUAL_INDEX = -1;
  *                                            visual data can be array or object
  *                                            (like: {cate1: '#222', none: '#fff'})
  *                                            or primary types (which represents
- *                                            defualt category visual), otherwise visual
+ *                                            default category visual), otherwise visual
  *                                            can be array or primary (which will be
  *                                            normalized to array).
  *


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Replace typos in comments defining something as "defualt".


### Fixed issues


## Details

### Before: What was the problem?

Comments had sometimes defualt instead of default (inverting au).


### After: How is it fixed in this PR?

Typos are fixed, replacing defualt with default.

### Other information

Changes only to comments - code did not show these typos.


I hope it's ok to exclude dist (i understand that's only updated by a release?). 
If not let me know.