### PR TITLE
fix(title): incorrect redirect when sublink is clicked.

### DIFF
--- a/src/component/title.js
+++ b/src/component/title.js
@@ -149,7 +149,7 @@ echarts.extendComponentView({
         }
         if (sublink) {
             subTextEl.on('click', function () {
-                windowOpen(link, '_' + titleModel.get('subtarget'));
+                windowOpen(sublink, '_' + titleModel.get('subtarget'));
             });
         }
 


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixed #12841, which was brought by #12380.
When `sublink` is cliked, a wrong link(should be `sublink`, but `link` in fact) will be opened. 

### Fixed issues

- #12841

## Usage

### Are there any API changes?

- [ ] The API has been changed.

### Related test cases or examples to use the new APIs

NA.
