### PR TITLE
fix(lines): lines series shouldn't disappear after `setOption({})`. (#12836)

### DIFF
--- a/src/chart/lines/LinesSeries.js
+++ b/src/chart/lines/LinesSeries.js
@@ -80,8 +80,6 @@ var LinesSeries = SeriesModel.extend({
     },
 
     mergeOption: function (option) {
-        // The input data may be null/undefined.
-        option.data = option.data || [];
 
         compatEc2(option);
 

--- a/test/lines-mergeOption.html
+++ b/test/lines-mergeOption.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            .test-title {
+                background: #146402;
+                color: #fff;
+            }
+        </style>
+
+
+        <div id="main0"></div>
+
+        <script>
+
+            // See <https://github.com/apache/incubator-echarts/issues/12836>
+
+            var chart;
+            var myChart;
+            var option;
+
+            require([
+                'echarts'
+            ], function (echarts) {
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: [
+                        {
+                            scale: true,
+                        },
+                    ],
+                    series: [
+                        {
+                            data: [1320, 1800],
+                            type: 'line'
+                        },
+                        {
+                            type: 'lines',
+                            coordinateSystem: 'cartesian2d',
+                            data: [{
+                                coords: [
+                                    ['Tue', 1500],
+                                    ['Thu', 1800]
+                                ]
+                            }, {
+                                coords: [
+                                    ['Fri', 1600],
+                                    ['Sat', 1400]
+                                ]
+                            }]
+                        }
+                    ]
+                };
+
+                chart = myChart = testHelper.create(echarts, 'main0', {
+                    title: ['lines series should not disappear after `chart.setOption({})`'],
+                    option: option,
+                    info: option,
+                    button: {
+                        text: 'Click to setOption({})',
+                        onClick: function () {
+                            myChart.setOption({});
+                        }
+                    }
+                });
+            });
+
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fixes the bug that lines series will disappear after `setOption({})`, closes #12836.

### Fixed issues

- #12836
- #9212

## Details

### Before: What was the problem?

See #12836, #9212


### After: How is it fixed in this PR?

Tweaked `LinesSeries.mergeOption`, removed the code line below
```js
option.data = option.data || [];
```

## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

Refer to `test/lines-mergeOption.html`.
