### PR TITLE
fix(tree) The chart line color is not updated when updating a node's lineStyle

### DIFF
--- a/src/chart/tree/TreeView.js
+++ b/src/chart/tree/TreeView.js
@@ -469,7 +469,7 @@ function drawEdge(
 
             graphic.updateProps(edge, {
                 shape: getEdgeShape(seriesScope, sourceLayout, targetLayout),
-                style: {opacity: 1}
+                style: zrUtil.defaults({opacity: 1}, seriesScope.lineStyle)
             }, seriesModel);
         }
     }
@@ -499,7 +499,7 @@ function drawEdge(
                         parentPoint: [targetLayout.x, targetLayout.y],
                         childPoints: childPoints
                     },
-                    style: {opacity: 1}
+                    style: zrUtil.defaults({opacity: 1}, seriesScope.lineStyle)
                 }, seriesModel);
             }
         }


### PR DESCRIPTION
update line color when update charts

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
