### PR TITLE
feat(bot): added .gitattributes file to exclude files needed to ignore for pull-request-size bot.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# for pull request size bot
+# excludes all files from test directory
+test/** linguist-generated=true


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Currently, the pull-request-size bot calculates the size of PR without excluding the files in `test` directory.
Here I've tried to add a `.gitattributes` file to make bot ignore them.

**Because the `.gitattributes` file is originally used to specify properties for listed files in it for git, I'm not sure whether it will bring something unexpected.**

Ref:
- https://docs.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github
- https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings#per-repository-settings

