### PR TITLE
Fix: radar model mixin with  AxisModelCommonMixin

### DIFF
--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -20,7 +20,6 @@
 import * as zrUtil from 'zrender/src/core/util';
 import axisDefault from '../axisDefault';
 import Model from '../../model/Model';
-import {AxisModelCommonMixin} from '../axisModelCommonMixin';
 import ComponentModel from '../../model/Component';
 import {
     ComponentOption,
@@ -32,6 +31,7 @@ import { AxisBaseOption } from '../axisCommonTypes';
 import { AxisBaseModel } from '../AxisBaseModel';
 import Radar from './Radar';
 import {CoordinateSystemHostModel} from '../../coord/CoordinateSystem';
+import {mixinAxisModelCommonMethods} from '../../helper';
 
 const valueAxisDefault = axisDefault.value;
 
@@ -151,11 +151,9 @@ class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystem
                     innerIndicatorOpt.name, innerIndicatorOpt
                 );
             }
-            const model = zrUtil.extend(
-                new Model(innerIndicatorOpt, null, this.ecModel),
-                AxisModelCommonMixin.prototype
-            ) as AxisBaseModel<InnerIndicatorAxisOption>;
 
+            mixinAxisModelCommonMethods(Model);
+            const model = new Model(innerIndicatorOpt, null, this.ecModel) as AxisBaseModel<InnerIndicatorAxisOption>;
             // For triggerEvent.
             model.mainType = 'radar';
             model.componentIndex = this.componentIndex;

--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -20,6 +20,7 @@
 import * as zrUtil from 'zrender/src/core/util';
 import axisDefault from '../axisDefault';
 import Model from '../../model/Model';
+import {AxisModelCommonMixin} from '../axisModelCommonMixin';
 import ComponentModel from '../../model/Component';
 import {
     ComponentOption,
@@ -31,7 +32,6 @@ import { AxisBaseOption } from '../axisCommonTypes';
 import { AxisBaseModel } from '../AxisBaseModel';
 import Radar from './Radar';
 import {CoordinateSystemHostModel} from '../../coord/CoordinateSystem';
-import {mixinAxisModelCommonMethods} from '../../helper';
 
 const valueAxisDefault = axisDefault.value;
 
@@ -152,8 +152,8 @@ class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystem
                 );
             }
 
-            mixinAxisModelCommonMethods(Model);
             const model = new Model(innerIndicatorOpt, null, this.ecModel) as AxisBaseModel<InnerIndicatorAxisOption>;
+            zrUtil.mixin(model, AxisModelCommonMixin.prototype);
             // For triggerEvent.
             model.mainType = 'radar';
             model.componentIndex = this.componentIndex;

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -103,6 +103,6 @@ export function createScale(dataExtent: number[], option: object | AxisBaseModel
  * `getMax(origin: boolean) => number`
  * `getNeedCrossZero() => boolean`
  */
-export function mixinAxisModelCommonMethods<T = Model>(Model: T) {
+export function mixinAxisModelCommonMethods(Model: Model) {
     zrUtil.mixin(Model, AxisModelCommonMixin);
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -103,6 +103,6 @@ export function createScale(dataExtent: number[], option: object | AxisBaseModel
  * `getMax(origin: boolean) => number`
  * `getNeedCrossZero() => boolean`
  */
-export function mixinAxisModelCommonMethods(Model: Model) {
+export function mixinAxisModelCommonMethods<T = Model>(Model: T) {
     zrUtil.mixin(Model, AxisModelCommonMixin);
 }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Use `mixinAxisModelCommonMethods` to mix radar axis model with `AxisModelCommonMixin`


### Fixed issues


## Details

### Before: What was the problem?

`AxisBaseModel` don't have `getNeedCrossZero` method

<img width="515" alt="Screen Shot 2020-07-08 at 23 15 59" src="https://user-images.githubusercontent.com/20318608/86936774-09e9bd80-c171-11ea-8899-3f41b0bdda27.png">




### After: How is it fixed in this PR?

No error



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
