### PR TITLE
[5.0] feat(animation): action from dataZoom and resize can override the animation in series.

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -780,6 +780,7 @@ class LineView extends ChartView {
 
         if (polygon) {
             polygon.setShape({
+                // Reuse the points with polyline.
                 points: current,
                 stackedOnPoints: stackedOnCurrent
             });
@@ -789,7 +790,12 @@ class LineView extends ChartView {
                     stackedOnPoints: stackedOnNext
                 }
             }, seriesModel);
+            // If use attr directly in updateProps.
+            if (polyline.shape.points !== polygon.shape.points) {
+                polygon.shape.points = polyline.shape.points;
+            }
         }
+
 
         const updatedDataInfo: {
             el: SymbolExtended,

--- a/src/chart/parallel/ParallelView.ts
+++ b/src/chart/parallel/ParallelView.ts
@@ -53,9 +53,7 @@ class ParallelView extends ChartView {
         seriesModel: ParallelSeriesModel,
         ecModel: GlobalModel,
         api: ExtensionAPI,
-        payload: Payload & {
-            animation?: boolean
-        }
+        payload: Payload
     ) {
         const dataGroup = this._dataGroup;
         const data = seriesModel.getData();
@@ -80,8 +78,8 @@ class ParallelView extends ChartView {
 
             const points = createLinePoints(data, newDataIndex, dimensions, coordSys);
             data.setItemGraphicEl(newDataIndex, line);
-            const animationModel = (payload && payload.animation === false) ? null : seriesModel;
-            graphic.updateProps(line, {shape: {points: points}}, animationModel, newDataIndex);
+
+            graphic.updateProps(line, {shape: {points: points}}, seriesModel, newDataIndex);
 
             updateElCommon(line, data, newDataIndex, seriesScope);
         }

--- a/src/component/axis/ParallelAxisView.ts
+++ b/src/component/axis/ParallelAxisView.ts
@@ -103,8 +103,7 @@ class ParallelAxisView extends ComponentView {
             builderOpt, areaSelectStyle, axisModel, coordSysModel, areaWidth, api
         );
 
-        const animationModel = (payload && payload.animation === false) ? null : axisModel;
-        graphic.groupTransition(oldAxisGroup, this._axisGroup, animationModel);
+        graphic.groupTransition(oldAxisGroup, this._axisGroup, axisModel);
     }
 
     // /**

--- a/src/component/axis/parallelAxisAction.ts
+++ b/src/component/axis/parallelAxisAction.ts
@@ -46,8 +46,6 @@ echarts.registerAction(actionInfo, function (payload: ParallelAxisAreaSelectPayl
 
 export interface ParallelAxisExpandPayload extends Payload {
     axisExpandWindow?: number[];
-    // Jumping uses animation, and sliding suppresses animation.
-    animation?: boolean;
 }
 
 /**

--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -752,6 +752,10 @@ class SliderZoomView extends DataZoomView {
             type: 'dataZoom',
             from: this.uid,
             dataZoomId: this.dataZoomModel.id,
+            animation: {
+                easing: 'cubicOut',
+                duration: 100
+            },
             start: range[0],
             end: range[1]
         });

--- a/src/component/dataZoom/roams.ts
+++ b/src/component/dataZoom/roams.ts
@@ -181,6 +181,10 @@ function cleanStore(store: Store) {
 function dispatchAction(api: ExtensionAPI, batch: DataZoomPayloadBatchItem[]) {
     api.dispatchAction({
         type: 'dataZoom',
+        animation: {
+            easing: 'cubicOut',
+            duration: 100
+        },
         batch: batch
     });
 }

--- a/src/component/parallel.ts
+++ b/src/component/parallel.ts
@@ -157,7 +157,9 @@ const handlers: Partial<Record<ElementEventName, ElementEventHandler>> = {
                 : {
                     axisExpandWindow: result.axisExpandWindow,
                     // Jumping uses animation, and sliding suppresses animation.
-                    animation: behavior === 'jump' ? null : false
+                    animation: behavior === 'jump' ? null : {
+                        duration: 0 // Disable animation.
+                    }
                 }
         );
     }

--- a/src/echarts.ts
+++ b/src/echarts.ts
@@ -1000,7 +1000,13 @@ class ECharts extends Eventful {
         this[IN_MAIN_PROCESS] = true;
 
         optionChanged && prepare(this);
-        updateMethods.update.call(this);
+        updateMethods.update.call(this, {
+            type: 'resize',
+            animation: {
+                // Disable animation
+                duration: 0
+            }
+        });
 
         this[IN_MAIN_PROCESS] = false;
 
@@ -1263,6 +1269,8 @@ class ECharts extends Eventful {
         ): void {
             const ecModel = ecIns._model;
 
+            ecModel.setUpdatePayload(payload);
+
             // broadcast
             if (!mainType) {
                 // FIXME
@@ -1322,6 +1330,8 @@ class ECharts extends Eventful {
                 if (!ecModel) {
                     return;
                 }
+
+                ecModel.setUpdatePayload(payload);
 
                 scheduler.restoreData(ecModel, payload);
 
@@ -1388,6 +1398,8 @@ class ECharts extends Eventful {
                     return;
                 }
 
+                ecModel.setUpdatePayload(payload);
+
                 // ChartView.markUpdateMethod(payload, 'updateTransform');
 
                 const componentDirtyList = [];
@@ -1438,6 +1450,8 @@ class ECharts extends Eventful {
                     return;
                 }
 
+                ecModel.setUpdatePayload(payload);
+
                 ChartView.markUpdateMethod(payload, 'updateView');
 
                 clearColorPalette(ecModel);
@@ -1459,6 +1473,8 @@ class ECharts extends Eventful {
                 if (!ecModel) {
                     return;
                 }
+
+                ecModel.setUpdatePayload(payload);
 
                 // clear all visual
                 ecModel.eachSeries(function (seriesModel) {

--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -86,6 +86,11 @@ class GlobalModel extends Model<ECUnitOption> {
      */
     private _seriesIndicesMap: HashMap<any>;
 
+    /**
+     * Model for store update payload
+     */
+    private _payload: Payload;
+
     // Injectable properties:
     scheduler: Scheduler;
 
@@ -316,6 +321,14 @@ class GlobalModel extends Model<ECUnitOption> {
 
     getTheme(): Model {
         return this._theme;
+    }
+
+    setUpdatePayload(payload: Payload) {
+        this._payload = payload;
+    }
+
+    getUpdatePayload(): Payload {
+        return this._payload;
     }
 
     /**

--- a/src/util/graphic.ts
+++ b/src/util/graphic.ts
@@ -66,7 +66,8 @@ import {
     TextCommonOption,
     SeriesOption,
     ParsedValue,
-    CallbackDataParams
+    CallbackDataParams,
+    AnimationPayload
 } from './types';
 import GlobalModel from '../model/Global';
 import { makeInner } from './model';
@@ -86,6 +87,7 @@ import * as numberUtil from './number';
 import SeriesModel from '../model/Series';
 import {interpolateNumber} from 'zrender/src/animation/Animator';
 import List from '../data/List';
+import easing, { AnimationEasing } from 'zrender/src/animation/easing';
 
 
 const mathMax = Math.max;
@@ -1161,32 +1163,52 @@ function animateOrSetProps<Props>(
     }
     const isUpdate = animationType === 'update';
     const isRemove = animationType === 'remove';
-    // Do not check 'animation' property directly here. Consider this case:
-    // animation model is an `itemModel`, whose does not have `isAnimationEnabled`
-    // but its parent model (`seriesModel`) does.
+
+    let animationPayload: AnimationPayload;
+    // Check if there is global animation configuration from dataZoom/resize can override the config in option.
+    // If animation is enabled. Will use this animation config in payload.
+    // If animation is disabled. Just ignore it.
+    if (animatableModel && animatableModel.ecModel) {
+        const updatePayload = animatableModel.ecModel.getUpdatePayload();
+        animationPayload = (updatePayload && updatePayload.animation) as AnimationPayload;
+    }
     const animationEnabled = animatableModel && animatableModel.isAnimationEnabled();
 
     if (animationEnabled) {
-        // TODO Configurable
-        let duration = isRemove ? 200 : animatableModel.getShallow(
-            isUpdate ? 'animationDurationUpdate' : 'animationDuration'
-        );
-        const animationEasing = isRemove ? 'cubicOut' : animatableModel.getShallow(
-            isUpdate ? 'animationEasingUpdate' : 'animationEasing'
-        );
-        let animationDelay = isRemove ? 0 : animatableModel.getShallow(
-            isUpdate ? 'animationDelayUpdate' : 'animationDelay'
-        );
-        if (typeof animationDelay === 'function') {
-            animationDelay = animationDelay(
-                dataIndex as number,
-                animatableModel.getAnimationDelayParams
-                    ? animatableModel.getAnimationDelayParams(el, dataIndex as number)
-                    : null
-            );
+        let duration: number | Function;
+        let animationEasing: AnimationEasing;
+        let animationDelay: number | Function;
+        if (animationPayload) {
+            duration = animationPayload.duration || 0;
+            animationEasing = animationPayload.easing || 'cubicOut';
+            animationDelay = animationPayload.delay || 0;
         }
-        if (typeof duration === 'function') {
-            duration = duration(dataIndex as number);
+        else if (isRemove) {
+            duration = 200;
+            animationEasing = 'cubicOut';
+            animationDelay = 0;
+        }
+        else {
+            duration = animatableModel.getShallow(
+                isUpdate ? 'animationDurationUpdate' : 'animationDuration'
+            );
+            animationEasing = animatableModel.getShallow(
+                isUpdate ? 'animationEasingUpdate' : 'animationEasing'
+            );
+            animationDelay = animatableModel.getShallow(
+                isUpdate ? 'animationDelayUpdate' : 'animationDelay'
+            );
+            if (typeof animationDelay === 'function') {
+                animationDelay = animationDelay(
+                    dataIndex as number,
+                    animatableModel.getAnimationDelayParams
+                        ? animatableModel.getAnimationDelayParams(el, dataIndex as number)
+                        : null
+                );
+            }
+            if (typeof duration === 'function') {
+                duration = duration(dataIndex as number);
+            }
         }
 
         if (!isRemove) {
@@ -1198,8 +1220,8 @@ function animateOrSetProps<Props>(
             ? (
                 isFrom
                     ? el.animateFrom(props, {
-                        duration,
-                        delay: animationDelay || 0,
+                        duration: duration as number,
+                        delay: animationDelay as number || 0,
                         easing: animationEasing,
                         done: cb,
                         force: !!cb || !!during,
@@ -1207,8 +1229,8 @@ function animateOrSetProps<Props>(
                         during: during
                     })
                     : el.animateTo(props, {
-                        duration,
-                        delay: animationDelay || 0,
+                        duration: duration as number,
+                        delay: animationDelay as number || 0,
                         easing: animationEasing,
                         done: cb,
                         force: !!cb || !!during,

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -127,6 +127,7 @@ export interface DataModel extends DataHost, DataFormatMixin {}
 
 interface PayloadItem {
     excludeSeriesId?: string | string[];
+    animation?: AnimationPayload
     [other: string]: any;
 }
 
@@ -134,6 +135,13 @@ export interface Payload extends PayloadItem {
     type: string;
     escapeConnect?: boolean;
     batch?: PayloadItem[];
+}
+
+// Payload includes override anmation info
+export interface AnimationPayload {
+    duration?: number
+    easing?: AnimationEasing
+    delay?: number
 }
 
 export interface ViewRootGroup extends Group {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

Currently, we use the `animationUpate` options in series to transit the elements when data updated.

But in the case which user can trigger the update frequently, like dataZoom, resize. The long animation duration may let chart seems to be not responsive. Especially when we changed the default easing from `'cubicOut'` to `'cubicInOut'`.  

So this pull request can let dataZoom and resize pass global animation config through payload. And when series do update, it will use the config in the payload instead of the animation config in the series. It will make the update faster, more responsive, and neater.

## Result

### DataZoom with Mouse Pan

#### Before
![dataZoom-inside-before](https://user-images.githubusercontent.com/841551/87419289-cfb36c80-c605-11ea-9a93-e8503e662bf4.gif)

#### After
![dataZoom-inside-after](https://user-images.githubusercontent.com/841551/87419298-d215c680-c605-11ea-893e-00b3b504619c.gif)

### DataZoom with Slider

#### Before
![dataZoom-slider-before](https://user-images.githubusercontent.com/841551/87419845-c8d92980-c606-11ea-8f4a-a2540d10bac5.gif)

#### After
![dataZoom-slider-after](https://user-images.githubusercontent.com/841551/87419838-c5de3900-c606-11ea-9e06-f05ddb6a1bec.gif)

### Resize the Pie

#### Before
![resize-before](https://user-images.githubusercontent.com/841551/87419865-d098ce00-c606-11ea-9fca-94e759d2f283.gif)

#### After
![resize-after](https://user-images.githubusercontent.com/841551/87419860-cd9ddd80-c606-11ea-899e-f2275ce68090.gif)

