### PR TITLE
feat: make line bolder when line is in emphasis state, designed by #12931.

### DIFF
--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -62,7 +62,9 @@ export interface LineDataItemOption extends SymbolOptionMixin,
 
 export interface LineSeriesOption extends SeriesOption<LineStateOption, ExtraStateOption & {
     emphasis?: {
-        lineStyle?: LineStyleOption
+        lineStyle?: LineStyleOption | {
+            width?: 'bolder'
+        }
         areaStyle?: AreaStyleOption
     }
     blur?: {
@@ -148,7 +150,9 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
 
         emphasis: {
             scale: true,
-            bolder: true
+            lineStyle: {
+                width: 'bolder'
+            }
         },
         // areaStyle: {
             // origin of areaStyle. Valid values:

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -103,6 +103,8 @@ export interface LineSeriesOption extends SeriesOption<LineStateOption, ExtraSta
     showAllSymbol?: 'auto'
 
     data?: (LineDataValue | LineDataItemOption)[]
+
+    bolderWhenHover?: boolean
 }
 
 class LineSeriesModel extends SeriesModel<LineSeriesOption> {
@@ -182,7 +184,9 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
 
         // Disable progressive
         progressive: 0,
-        hoverLayerThreshold: Infinity
+        hoverLayerThreshold: Infinity,
+
+        bolderWhenHover: true
     };
 }
 

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -42,7 +42,8 @@ type LineDataValue = OptionDataValue | OptionDataValue[];
 
 interface ExtraStateOption {
     emphasis?: {
-        scale?: boolean
+        scale?: boolean,
+        bolder?: boolean
     }
 }
 
@@ -103,8 +104,6 @@ export interface LineSeriesOption extends SeriesOption<LineStateOption, ExtraSta
     showAllSymbol?: 'auto'
 
     data?: (LineDataValue | LineDataItemOption)[]
-
-    bolderWhenHover?: boolean
 }
 
 class LineSeriesModel extends SeriesModel<LineSeriesOption> {
@@ -148,7 +147,8 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
         },
 
         emphasis: {
-            scale: true
+            scale: true,
+            bolder: true
         },
         // areaStyle: {
             // origin of areaStyle. Valid values:
@@ -184,9 +184,7 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
 
         // Disable progressive
         progressive: 0,
-        hoverLayerThreshold: Infinity,
-
-        bolderWhenHover: true
+        hoverLayerThreshold: Infinity
     };
 }
 

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -42,8 +42,7 @@ type LineDataValue = OptionDataValue | OptionDataValue[];
 
 interface ExtraStateOption {
     emphasis?: {
-        scale?: boolean,
-        bolder?: boolean
+        scale?: boolean
     }
 }
 

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -550,8 +550,8 @@ class LineView extends ChartView {
 
         setStatesStylesFromModel(polyline, seriesModel, 'lineStyle');
 
-        const bolderWhenHover = seriesModel.get('bolderWhenHover');
-        if (bolderWhenHover) {
+        const emphasisModel = seriesModel.getModel('emphasis');
+        if (emphasisModel.get('bolder')) {
             const emphasisLineStyle = polyline.getState('emphasis').style;
             // only bolder when `emphasis.lineStyle.width` is not specified
             if (emphasisLineStyle.lineWidth == null) {

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -550,8 +550,8 @@ class LineView extends ChartView {
 
         setStatesStylesFromModel(polyline, seriesModel, 'lineStyle');
 
-        const emphasisModel = seriesModel.getModel('emphasis');
-        if (emphasisModel.get('bolder')) {
+        const shouldBolder = seriesModel.get(['emphasis', 'bolder']);
+        if (shouldBolder) {
             const emphasisLineStyle = polyline.getState('emphasis').style;
             // only bolder when `emphasis.lineStyle.width` is not specified
             if (emphasisLineStyle.lineWidth == null) {

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -544,11 +544,21 @@ class LineView extends ChartView {
             {
                 fill: 'none',
                 stroke: visualColor,
-                lineJoin: 'bevel'
+                lineJoin: 'bevel' as CanvasLineJoin
             }
         ));
 
         setStatesStylesFromModel(polyline, seriesModel, 'lineStyle');
+
+        const bolderWhenHover = seriesModel.get('bolderWhenHover');
+        if (bolderWhenHover) {
+            const emphasisLineStyle = polyline.getState('emphasis').style;
+            // only bolder when `emphasis.lineStyle.width` is not specified
+            if (emphasisLineStyle.lineWidth == null) {
+                emphasisLineStyle.lineWidth = lineStyleModel.get('width') + 1;
+            }
+        }
+
         // Needs seriesIndex for focus
         graphic.getECData(polyline).seriesIndex = seriesModel.seriesIndex;
         enableHoverEmphasis(polyline, focus, blurScope);
@@ -569,7 +579,7 @@ class LineView extends ChartView {
                 {
                     fill: visualColor,
                     opacity: 0.7,
-                    lineJoin: 'bevel'
+                    lineJoin: 'bevel' as CanvasLineJoin
                 }
             ));
 

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -550,13 +550,10 @@ class LineView extends ChartView {
 
         setStatesStylesFromModel(polyline, seriesModel, 'lineStyle');
 
-        const shouldBolder = seriesModel.get(['emphasis', 'bolder']);
-        if (shouldBolder) {
+        const shouldBolderOnEmphasis = seriesModel.get(['emphasis', 'lineStyle', 'width']) === 'bolder';
+        if (shouldBolderOnEmphasis) {
             const emphasisLineStyle = polyline.getState('emphasis').style;
-            // only bolder when `emphasis.lineStyle.width` is not specified
-            if (emphasisLineStyle.lineWidth == null) {
-                emphasisLineStyle.lineWidth = lineStyleModel.get('width') + 1;
-            }
+            emphasisLineStyle.lineWidth = lineStyleModel.get('width') + 1;
         }
 
         // Needs seriesIndex for focus

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -553,7 +553,7 @@ class LineView extends ChartView {
         const shouldBolderOnEmphasis = seriesModel.get(['emphasis', 'lineStyle', 'width']) === 'bolder';
         if (shouldBolderOnEmphasis) {
             const emphasisLineStyle = polyline.getState('emphasis').style;
-            emphasisLineStyle.lineWidth = lineStyleModel.get('width') + 1;
+            emphasisLineStyle.lineWidth = polyline.style.lineWidth + 1;
         }
 
         // Needs seriesIndex for focus

--- a/src/coord/cartesian/GridModel.ts
+++ b/src/coord/cartesian/GridModel.ts
@@ -34,7 +34,7 @@ export interface GridOption extends ComponentOption, BoxLayoutOptionMixin, Shado
     borderWidth?: number;
     borderColor?: ZRColor;
 
-    tooltop?: any; // FIXME:TS add this tooltip type
+    tooltip?: any; // FIXME:TS add this tooltip type
 }
 
 class GridModel extends ComponentModel<GridOption> implements CoordinateSystemHostModel {

--- a/test/line-boldWhenHover.html
+++ b/test/line-boldWhenHover.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/esl.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <div id="main0"></div>
+    <div></div>
+    <script>
+        var chart;
+        var myChart;
+
+        require([
+            'echarts'
+        ], function (echarts) {
+            var option = {
+                legend: {
+                    left: 'center',
+                    bottom: 'bottom'
+                },
+                xAxis: {
+                    type: 'category',
+                    data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        name: 'line series 1',
+                        type: 'line',
+                        data: [28.5, 70.5, 108.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4],
+                        symbolSize: 10,
+                        symbol: 'square',
+                        bolderWhenHover: false,
+                        emphasis: {
+                            focus: 'series',
+                            lineStyle: {
+                                width: 5
+                            }
+                        }
+                    },
+                    {
+                        name: 'line series 2',
+                        type: 'line',
+                        data: [226.9, 194.1, 95.6, 54.4, 29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5],
+                        symbolSize: 10,
+                        symbol: 'circle',
+                        emphasis: {
+                            focus: 'series'
+                        }
+                    }
+                ]
+            };
+
+            chart = myChart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'For lineThe line should be bolder when hover'
+                ],
+                option: option
+            });
+        });
+
+    </script>
+</body>
+
+</html>

--- a/test/line-boldWhenHover.html
+++ b/test/line-boldWhenHover.html
@@ -60,7 +60,6 @@ under the License.
                         symbol: 'square',
                         emphasis: {
                             focus: 'series',
-                            //bolder: false,
                             lineStyle: {
                                 width: 5
                             }
@@ -73,8 +72,7 @@ under the License.
                         symbolSize: 10,
                         symbol: 'circle',
                         emphasis: {
-                            focus: 'series',
-                            //bolder: false
+                            focus: 'series'
                         }
                     }
                 ]

--- a/test/line-boldWhenHover.html
+++ b/test/line-boldWhenHover.html
@@ -81,7 +81,7 @@ under the License.
 
             chart = myChart = testHelper.create(echarts, 'main0', {
                 title: [
-                    'For lineThe line should be bolder when hover'
+                    'The line should be bolder when hovering on it'
                 ],
                 option: option
             });

--- a/test/line-boldWhenHover.html
+++ b/test/line-boldWhenHover.html
@@ -58,9 +58,9 @@ under the License.
                         data: [28.5, 70.5, 108.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4],
                         symbolSize: 10,
                         symbol: 'square',
-                        bolderWhenHover: false,
                         emphasis: {
                             focus: 'series',
+                            //bolder: false,
                             lineStyle: {
                                 width: 5
                             }
@@ -73,7 +73,8 @@ under the License.
                         symbolSize: 10,
                         symbol: 'circle',
                         emphasis: {
-                            focus: 'series'
+                            focus: 'series',
+                            //bolder: false
                         }
                     }
                 ]


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
According to the suggested design change in #12931, add a new semantic value `bolder` for `emphasis.lineStyle.width` for line series to specify whether the line should be bolder when it's in emphasis state.

### Fixed issues

- #12931


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
The line series won't be bolder to highlight when hovering on it unless users specify `emphasis.lineStyle.width`.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
By default, the line series will be bolder when hovering on it. But if users set `emphasis.lineStyle.width` as a specific number manually, it will be bolder as they specified.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![2020-07-23 17 09 35](https://user-images.githubusercontent.com/26999792/88269957-7c2cd700-cd07-11ea-9725-475ed78b44fc.gif)



## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->
Added a new semantic value `bolder` for `emphasis.lineStyle.width` , default value is `bolder`.

### Related test cases or examples to use the new APIs

Refer to `test/line-boldWhenHover.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
