### PR TITLE
fix(util/number): the `parseDate` function failed to parse a date string like `2020-07-29 09:2:5`.

### DIFF
--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -283,7 +283,7 @@ export function isRadianAroundZero(val: number): boolean {
 }
 
 // eslint-disable-next-line
-const TIME_REG = /^(?:(\d{4})(?:[-\/](\d{1,2})(?:[-\/](\d{1,2})(?:[T ](\d{1,2})(?::(\d\d)(?::(\d\d)(?:[.,](\d+))?)?)?(Z|[\+\-]\d\d:?\d\d)?)?)?)?)?$/; // jshint ignore:line
+const TIME_REG = /^(?:(\d{4})(?:[-\/](\d{1,2})(?:[-\/](\d{1,2})(?:[T ](\d{1,2})(?::(\d{1,2})(?::(\d{1,2})(?:[.,](\d+))?)?)?(Z|[\+\-]\d\d:?\d\d)?)?)?)?)?$/; // jshint ignore:line
 
 /**
  * @param value These values can be accepted:


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix a bug that the `parseDate` function can not parse a date string like `2020-07-29 09:2:5`.
The minute/second has only one number, not padding with 0.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information

Another potential bug about time is mentioned in https://github.com/apache/incubator-echarts/pull/13039#discussion_r462147069