### PR TITLE
fix(util/styleCompat): fix a typo in `convertToEC4RichItem` function.

### DIFF
--- a/src/util/styleCompat.ts
+++ b/src/util/styleCompat.ts
@@ -215,7 +215,7 @@ function convertToEC4RichItem(out: Dictionary<unknown>, richItem: TextStyleProps
     hasOwn(richItem, 'stroke') && (out.textStroke = richItem.fill);
 
     hasOwn(richItem, 'lineWidth') && (out.textStrokeWidth = richItem.lineWidth);
-    hasOwn(richItem, 'font') && (out.textStrokeWidth = richItem.font);
+    hasOwn(richItem, 'font') && (out.font = richItem.font);
     hasOwn(richItem, 'fontStyle') && (out.fontStyle = richItem.fontStyle);
     hasOwn(richItem, 'fontWeight') && (out.fontWeight = richItem.fontWeight);
     hasOwn(richItem, 'fontSize') && (out.fontSize = richItem.fontSize);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
There may be a typo in `out.textStrokeWidth = richItem.font`, which should be `out.font= richItem.font`.



## Usage

### Related test cases or examples to use the new APIs

NA.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
