### PR TITLE
fix: recover auto rotation for line symbol.

### DIFF
--- a/src/chart/helper/Line.js
+++ b/src/chart/helper/Line.js
@@ -57,8 +57,8 @@ function createSymbol(name, lineData, idx) {
     );
 
     // rotate by default if symbolRotate is not specified or NaN
-    symbolPath.rotation = symbolRotate == null || isNaN(symbolRotate)
-        ? undefined
+    symbolPath.__specifiedRotation = symbolRotate == null || isNaN(symbolRotate)
+        ? void 0
         : +symbolRotate * Math.PI / 180 || 0;
     symbolPath.name = name;
 
@@ -131,12 +131,15 @@ function updateSymbolAndLabelBeforeLineUpdate() {
         // when symbol is set to be 'arrow' in markLine,
         // symbolRotate value will be ignored, and compulsively use tangent angle.
         // rotate by default if symbol rotation is not specified
-        if (symbolFrom.rotation == null
-            || (symbolFrom.shape && symbolFrom.shape.symbolType === 'arrow')) {
+        var specifiedRotation = symbolFrom.__specifiedRotation;
+        if (specifiedRotation == null) {
             var tangent = line.tangentAt(0);
             symbolFrom.attr('rotation', Math.PI / 2 - Math.atan2(
                 tangent[1], tangent[0]
             ));
+        }
+        else {
+            symbolFrom.attr('rotation', specifiedRotation);
         }
         symbolFrom.attr('scale', [invScale * percent, invScale * percent]);
     }
@@ -146,12 +149,15 @@ function updateSymbolAndLabelBeforeLineUpdate() {
         // when symbol is set to be 'arrow' in markLine,
         // symbolRotate value will be ignored, and compulsively use tangent angle.
         // rotate by default if symbol rotation is not specified
-        if (symbolTo.rotation == null
-            || (symbolTo.shape && symbolTo.shape.symbolType === 'arrow')) {
+        var specifiedRotation = symbolTo.__specifiedRotation;
+        if (specifiedRotation == null) {
             var tangent = line.tangentAt(1);
             symbolTo.attr('rotation', -Math.PI / 2 - Math.atan2(
                 tangent[1], tangent[0]
             ));
+        }
+        else {
+            symbolTo.attr('rotation', specifiedRotation);
         }
         symbolTo.attr('scale', [invScale * percent, invScale * percent]);
     }

--- a/test/markLine-symbolRotate.html
+++ b/test/markLine-symbolRotate.html
@@ -118,6 +118,10 @@ under the License.
                                 silent: true,
                                 // symbol: 'triangle',
                                 data: [
+                                [
+                                    {name: 'rotation not specified', coord: ['2014-06-20', 300], symbol: 'arrow'},
+                                    {coord: ['2014-07-18', 320], symbol: 'triangle'}
+                                ],
                                 {
                                     yAxis: 50,
                                     // symbolRotate: 0,
@@ -133,15 +137,18 @@ under the License.
                                     yAxis: 150,
                                     symbol: 'roundRect',
                                     symbolRotate: 40
-                                }, {
+                                },
+                                {
                                     yAxis: 200,
                                     symbol: 'diamond',
-                                    symbolRotate: 70
-                                }, {
+                                    symbolRotate: 45
+                                },
+                                {
                                     yAxis: 250,
                                     symbol: 'pin',
                                     symbolRotate: 45
-                                }, {
+                                },
+                                {
                                     yAxis: 300,
                                     symbol: 'circle',
                                     symbolRotate: 90
@@ -162,7 +169,9 @@ under the License.
                                     lineStyle: {
                                         color: '#14c4ba'
                                     }
-                                }]]
+                                }
+                                ]
+                                ]
                             }
                         }]
                     };


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

In Line.js (used by graph and markLine), when rotation is not specified by users, the "auto rotation" rule should not be broken when rendered at the second time (like when drag graph or move dataZoom). 

#12392 support the feature of support user specified symbol rotation in Line.js 
Line.js is used by graph and markLine and might other places.

But when rotation is not specified by users, the "auto rotation" rule should not be broken when rendered at the second time. 
The scenario of "render at the second time" are like dragging force layout graph or move dataZoom.
See the triangle below:

![line-fail](https://user-images.githubusercontent.com/1956569/89439334-9db4a680-d77c-11ea-8300-2d75f921cfbb.gif)

