### PR TITLE
fix(bar): showBackground bug when update with no previous background elements

### DIFF
--- a/src/chart/bar/BarView.js
+++ b/src/chart/bar/BarView.js
@@ -135,20 +135,25 @@ export default echarts.extendChartView({
         var bgEls = [];
         var oldBgEls = this._backgroundEls || [];
 
+        var createBackground = dataIndex => {
+            var bgLayout = getLayout[coord.type](data, dataIndex);
+            var bgEl = createBackgroundEl(coord, isHorizontalOrRadial, bgLayout);
+            bgEl.useStyle(backgroundModel.getBarItemStyle());
+            // Only cartesian2d support borderRadius.
+            if (coord.type === 'cartesian2d') {
+                bgEl.setShape('r', barBorderRadius);
+            }
+            bgEls[dataIndex] = bgEl;
+            return bgEl;
+        };
+
         data.diff(oldData)
             .add(function (dataIndex) {
                 var itemModel = data.getItemModel(dataIndex);
                 var layout = getLayout[coord.type](data, dataIndex, itemModel);
 
                 if (drawBackground) {
-                    var bgLayout = getLayout[coord.type](data, dataIndex);
-                    var bgEl = createBackgroundEl(coord, isHorizontalOrRadial, bgLayout);
-                    bgEl.useStyle(backgroundModel.getBarItemStyle());
-                    // Only cartesian2d support borderRadius.
-                    if (coord.type === 'cartesian2d') {
-                        bgEl.setShape('r', barBorderRadius);
-                    }
-                    bgEls[dataIndex] = bgEl;
+                    createBackground(dataIndex);
                 }
 
                 // If dataZoom in filteMode: 'empty', the baseValue can be set as NaN in "axisProxy".
@@ -182,13 +187,19 @@ export default echarts.extendChartView({
                 var layout = getLayout[coord.type](data, newIndex, itemModel);
 
                 if (drawBackground) {
-                    var bgEl = oldBgEls[oldIndex];
-                    bgEl.useStyle(backgroundModel.getBarItemStyle());
-                    // Only cartesian2d support borderRadius.
-                    if (coord.type === 'cartesian2d') {
-                        bgEl.setShape('r', barBorderRadius);
+                    var bgEl;
+                    if (oldBgEls.length === 0) {
+                        bgEl = createBackground(oldIndex);
                     }
-                    bgEls[newIndex] = bgEl;
+                    else {
+                        var bgEl = oldBgEls[oldIndex];
+                        bgEl.useStyle(backgroundModel.getBarItemStyle());
+                        // Only cartesian2d support borderRadius.
+                        if (coord.type === 'cartesian2d') {
+                            bgEl.setShape('r', barBorderRadius);
+                        }
+                        bgEls[newIndex] = bgEl;
+                    }
 
                     var bgLayout = getLayout[coord.type](data, newIndex);
                     var shape = createBackgroundShape(isHorizontalOrRadial, bgLayout, coord);

--- a/src/chart/bar/BarView.js
+++ b/src/chart/bar/BarView.js
@@ -135,7 +135,7 @@ export default echarts.extendChartView({
         var bgEls = [];
         var oldBgEls = this._backgroundEls || [];
 
-        var createBackground = dataIndex => {
+        var createBackground = function (dataIndex) {
             var bgLayout = getLayout[coord.type](data, dataIndex);
             var bgEl = createBackgroundEl(coord, isHorizontalOrRadial, bgLayout);
             bgEl.useStyle(backgroundModel.getBarItemStyle());


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix 13009


### Fixed issues

Switch 'options -> series -> showBackground' from `false` to `true` will no longer throw exceptions. (something like calling `useStyle` from undefined, more detailed described in #13009 )


## Details

### Before: What was the problem?

Switch 'options -> series -> showBackground' from `false` to `true` will throw exceptions.



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Switch 'options -> series -> showBackground' from `false` to `true` works well.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

No

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
