### PR TITLE
fix(bar): showBackground bug when update with no previous background elements

### DIFF
--- a/src/chart/bar/BarView.js
+++ b/src/chart/bar/BarView.js
@@ -192,7 +192,7 @@ export default echarts.extendChartView({
                         bgEl = createBackground(oldIndex);
                     }
                     else {
-                        var bgEl = oldBgEls[oldIndex];
+                        bgEl = oldBgEls[oldIndex];
                         bgEl.useStyle(backgroundModel.getBarItemStyle());
                         // Only cartesian2d support borderRadius.
                         if (coord.type === 'cartesian2d') {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix 13009
**Remove unnecessary var declaration, according to #13084**

### Fixed issues

Switch 'options -> series -> showBackground' from `false` to `true` will no longer throw exceptions. (something like calling `useStyle` from undefined, more detailed described in #13009 )


## Details

### Before: What was the problem?

Switch 'options -> series -> showBackground' from `false` to `true` will throw exceptions.



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Switch 'options -> series -> showBackground' from `false` to `true` works well.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

No

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
