### PR TITLE
fix: make `contentToOption` totally optional

### DIFF
--- a/src/component/toolbox/feature/DataView.js
+++ b/src/component/toolbox/feature/DataView.js
@@ -382,7 +382,7 @@ DataView.prototype.onclick = function (ecModel, api) {
             if (typeof contentToOption === 'function') {
                 newOption = contentToOption(viewMain, api.getOption());
             }
-            else {
+            else if (typeof contentToOption !== 'undefined') {
                 newOption = parseContents(textarea.value, blockMetaList);
             }
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix #13031 

### Fixed issues

#13031 has described such a situation that user has provided `optionToContent` function while has not provided the corresponding `contentToOption` function.
If we think echarts should also work well in this situation, we need to make `contentToOption` function totally optional. (In other words, if user hasn't provided it, bugs like missing series data or showing a list of `undefined` should not happen.)


## Details

### Before: What was the problem?

If user provide `optionToContent` function but has not provided `contentToOption` function, press 'refresh' will lose data and make a list of `undefined` displayed.



### After: How is it fixed in this PR?

Even user has not provided `contentToOption` function, by pressing 'refresh' button also works well.



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

No


### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
