### PR TITLE
fix(tooltip): keep axis tooltip open on refresh

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -212,9 +212,6 @@ class TooltipView extends ComponentView {
 
         this._api = api;
 
-        // Should be cleaned when render.
-        this._lastDataByCoordSys = null;
-
         /**
          * @private
          * @type {boolean}
@@ -272,7 +269,8 @@ class TooltipView extends ComponentView {
                 // FIXME
                 !api.isDisposed() && self.manuallyShowTip(tooltipModel, ecModel, api, {
                     x: self._lastX,
-                    y: self._lastY
+                    y: self._lastY,
+                    dataByCoordSys: self._lastDataByCoordSys
                 });
             });
         }
@@ -382,7 +380,7 @@ class TooltipView extends ComponentView {
             tooltipContent.hideLater(this._tooltipModel.get('hideDelay'));
         }
 
-        this._lastX = this._lastY = null;
+        this._lastX = this._lastY = this._lastDataByCoordSys = null;
 
         if (payload.from !== this.uid) {
             this._hide(makeDispatchAction(payload, api));


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing


### What does this PR do?

Fix a tooltip disappearing when tooltip trigger is "axis" and data is refreshed.



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

Chart with datazoom slider and live update every few seconds. The slider is somewhere in the middle with a fixed value range. When the user hovers over the data, the tooltip with trigger "axis" shows correctly. But as soon as new data is pushed to the chart the tooltip disappears. This PR fixes that.


### After: How is it fixed in this PR?

Tooltip with trigger axis stays when data is refresehd.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
