### PR TITLE
Fix: make `contentToOption` totally optional

### DIFF
--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -326,9 +326,7 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
         const textarea = document.createElement('textarea');
         viewMain.style.cssText = 'display:block;width:100%;overflow:auto;';
 
-        // function
         const optionToContent = model.get('optionToContent');
-        // undefined
         const contentToOption = model.get('contentToOption');
         const result = getContentFromModel(ecModel);
         if (typeof optionToContent === 'function') {

--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -326,7 +326,9 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
         const textarea = document.createElement('textarea');
         viewMain.style.cssText = 'display:block;width:100%;overflow:auto;';
 
+        // function
         const optionToContent = model.get('optionToContent');
+        // undefined
         const contentToOption = model.get('contentToOption');
         const result = getContentFromModel(ecModel);
         if (typeof optionToContent === 'function') {
@@ -371,6 +373,13 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
         addEventListener(closeButton, 'click', close);
 
         addEventListener(refreshButton, 'click', function () {
+            if ((typeof contentToOption === 'undefined' && typeof optionToContent !== 'undefined') ||
+            (typeof contentToOption !== 'undefined' && typeof optionToContent === 'undefined')) {
+                console.warn('It seems you have just provided one of `contentToOption` and `optionToContent` functions but missed the other one. Data change is ignored.')
+                close();
+                return;
+            }
+
             let newOption;
             try {
                 if (typeof contentToOption === 'function') {

--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -372,7 +372,7 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
 
         addEventListener(refreshButton, 'click', function () {
             if ((typeof contentToOption === 'undefined' && typeof optionToContent !== 'undefined') ||
-            (typeof contentToOption !== 'undefined' && typeof optionToContent === 'undefined')) {
+                (typeof contentToOption !== 'undefined' && typeof optionToContent === 'undefined')) {
                 console.warn('It seems you have just provided one of `contentToOption` and `optionToContent` functions but missed the other one. Data change is ignored.')
                 close();
                 return;

--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -371,9 +371,11 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
         addEventListener(closeButton, 'click', close);
 
         addEventListener(refreshButton, 'click', function () {
-            if ((typeof contentToOption === 'undefined' && typeof optionToContent !== 'undefined') ||
-                (typeof contentToOption !== 'undefined' && typeof optionToContent === 'undefined')) {
-                console.warn('It seems you have just provided one of `contentToOption` and `optionToContent` functions but missed the other one. Data change is ignored.')
+            if ((contentToOption == null && optionToContent != null) ||
+                (contentToOption != null && optionToContent == null)) {
+                if (__DEV__) {
+                    console.warn('It seems you have just provided one of `contentToOption` and `optionToContent` functions but missed the other one. Data change is ignored.')
+                }
                 close();
                 return;
             }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix #13031 and #13086 


### Fixed issues

#13031 has described such a situation that user has provided `optionToContent` function while has not provided the corresponding `contentToOption` function.
If we think echarts should also work well in this situation, we need to make `contentToOption` function totally optional. (In other words, if user hasn't provided it, bugs like missing series data or showing a list of `undefined` should not happen.)


## Details

### Before: What was the problem?

If user provide `optionToContent` function but has not provided `contentToOption` function, press 'refresh' will lose data and make a list of `undefined` displayed.



### After: How is it fixed in this PR?

Even user has not provided `contentToOption` function, by pressing 'refresh' button also works well.



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

No


### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
