### PR TITLE
Fix #13195 - Update way of parsing string to date

### DIFF
--- a/src/util/number.js
+++ b/src/util/number.js
@@ -343,7 +343,7 @@ export function parseDate(value) {
                 +match[4] || 0,
                 +(match[5] || 0),
                 +match[6] || 0,
-                +match[7] || 0
+                +(match[7]?match[7].substring(0,3):match[7]) || 0
             );
         }
         // Timezoneoffset of Javascript Date has considered DST (Daylight Saving Time,
@@ -365,7 +365,7 @@ export function parseDate(value) {
                 hour,
                 +(match[5] || 0),
                 +match[6] || 0,
-                +match[7] || 0
+                +(match[7]?match[7].substring(0,3):match[7]) || 0
             ));
         }
     }

--- a/test/data-time-parsing.html
+++ b/test/data-time-parsing.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/esl.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <div id="main0"></div>
+    <div></div>
+    <script>
+        var chart;
+        var myChart;
+
+        require([
+            'echarts'
+        ], function (echarts) {
+            var colorList = ['#33ff11', '#aa0088', '#224477', '#00ee44', '#6611ff', '#889911'];
+            var option = {
+                legend: {
+                    left: 'center',
+                    bottom: 'bottom'
+                },
+                xAxis: {
+                    type: 'time',
+                },
+                yAxis: {
+                    type: 'value',
+                },
+                grid: {
+                    bottom: 120
+                },
+                series: [
+                    {
+                        name: 'Same time value with different format',
+                        type: 'line',
+                        data: [['2020-08-26T20:30:00.698Z', 0], ['2020-08-26T20:30:00.6985Z', 5], ['2020-08-26T20:30:00.698000Z', 10]],
+                        symbolSize: 10                      
+                    }
+                ]
+            };
+
+            chart = myChart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Parsing time with milliseconds'
+                ],
+                option: option
+            });
+        });
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

The PR updated way of parsing 7th part of date string from simply treat it as milliseconds to pick first 3 digits as milliseconds to avoid unexpected result when backend API return date string with precision of microseconds.

### Fixed issues

#13195 


## Details

### Before: What was the problem?

Though 3 digits milliseconds is widely used in most situations, some date formatter will return date string 6 digit microseconds (`yyyy-MM-ddTHH:mm:ss.micros`) . ECharts will treat micro seconds as milliseconds when parsing DateTime string and cause unexpected result.

### After: How is it fixed in this PR?

Keep conistent with default constructor of JavaScript Date - only pick first 3 digits when the length of input part between dot and zulu time marker is longer than 3 digits.

## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
