### PR TITLE
[5.0] [Performance] Improve large line performance. Improve line smoothing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,7 +174,7 @@ map/raw
 theme/thumb
 pre-publish-tmp
 todo
-**/*.log
+*.log
 *.sublime-workspace
 *.sublime-project
 
@@ -192,3 +192,6 @@ todo
 /extension-esm
 /extension
 *.tgz
+
+# Result of node.js perf
+*.asm

--- a/src/chart/effectScatter/EffectScatterView.ts
+++ b/src/chart/effectScatter/EffectScatterView.ts
@@ -50,7 +50,7 @@ class EffectScatterView extends ChartView {
 
         this.group.dirty();
 
-        const res = pointsLayout().reset(seriesModel, ecModel, api) as StageHandlerProgressExecutor;
+        const res = pointsLayout('').reset(seriesModel, ecModel, api) as StageHandlerProgressExecutor;
         if (res.progress) {
             res.progress({
                 start: 0,

--- a/src/chart/helper/LargeSymbolDraw.ts
+++ b/src/chart/helper/LargeSymbolDraw.ts
@@ -190,7 +190,7 @@ class LargeSymbolDraw {
         });
 
         symbolEl.setShape({
-            points: data.getLayout('symbolPoints')
+            points: data.getLayout('points')
         });
         this._setCommon(symbolEl, data, false, opt);
         this.group.add(symbolEl);
@@ -203,7 +203,7 @@ class LargeSymbolDraw {
             return;
         }
 
-        let points = data.getLayout('symbolPoints');
+        let points = data.getLayout('points');
         this.group.eachChild(function (child: LargeSymbolPath) {
             if (child.startIndex != null) {
                 const len = (child.endIndex - child.startIndex) * 2;
@@ -251,7 +251,7 @@ class LargeSymbolDraw {
         }
 
         symbolEl.setShape({
-            points: data.getLayout('symbolPoints')
+            points: data.getLayout('points')
         });
         this._setCommon(symbolEl, data, !!this._incremental, opt);
     }

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -43,7 +43,6 @@ import { CoordinateSystemClipArea } from '../../coord/CoordinateSystem';
 import { setStatesStylesFromModel, setStatesFlag, enableHoverEmphasis } from '../../util/states';
 import { getECData } from '../../util/ecData';
 import { createFloat32Array } from '../../util/vendor';
-import { createSymbol } from '../../util/symbol';
 
 
 type PolarArea = ReturnType<Polar['getArea']>;
@@ -433,7 +432,7 @@ class LineView extends ChartView {
         const valueOrigin = areaStyleModel.get('origin');
         const dataCoordInfo = prepareDataCoordInfo(coordSys, data, valueOrigin);
 
-        let stackedOnPoints = getStackedOnPoints(coordSys, data, dataCoordInfo);
+        let stackedOnPoints = isAreaChart && getStackedOnPoints(coordSys, data, dataCoordInfo);
 
         const showSymbol = seriesModel.get('showSymbol');
 
@@ -490,7 +489,10 @@ class LineView extends ChartView {
             if (step) {
                 // TODO If stacked series is not step
                 points = turnPointsIntoStep(points, coordSys, step);
-                stackedOnPoints = turnPointsIntoStep(stackedOnPoints, coordSys, step);
+
+                if (stackedOnPoints) {
+                    stackedOnPoints = turnPointsIntoStep(stackedOnPoints, coordSys, step);
+                }
             }
 
             polyline = this._newPolyline(points);
@@ -548,7 +550,9 @@ class LineView extends ChartView {
                     if (step) {
                         // TODO If stacked series is not step
                         points = turnPointsIntoStep(points, coordSys, step);
-                        stackedOnPoints = turnPointsIntoStep(stackedOnPoints, coordSys, step);
+                        if (stackedOnPoints) {
+                            stackedOnPoints = turnPointsIntoStep(stackedOnPoints, coordSys, step);
+                        }
                     }
 
                     polyline.setShape({

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -594,10 +594,12 @@ class LineView extends ChartView {
         enableHoverEmphasis(polyline, focus, blurScope);
 
         const smooth = getSmooth(seriesModel.get('smooth'));
+        const smoothMonotone = seriesModel.get('smoothMonotone');
+        const connectNulls = seriesModel.get('connectNulls');
         polyline.setShape({
-            smooth: smooth,
-            smoothMonotone: seriesModel.get('smoothMonotone'),
-            connectNulls: seriesModel.get('connectNulls')
+            smooth,
+            smoothMonotone,
+            connectNulls
         });
 
         if (polygon) {
@@ -618,10 +620,10 @@ class LineView extends ChartView {
             }
 
             polygon.setShape({
-                smooth: smooth,
-                stackedOnSmooth: stackedOnSmooth,
-                smoothMonotone: seriesModel.get('smoothMonotone'),
-                connectNulls: seriesModel.get('connectNulls')
+                smooth,
+                stackedOnSmooth,
+                smoothMonotone,
+                connectNulls
             });
 
             setStatesStylesFromModel(polygon, seriesModel, 'areaStyle');

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -20,7 +20,6 @@
 // FIXME step not support polar
 
 import * as zrUtil from 'zrender/src/core/util';
-import {fromPoints} from 'zrender/src/core/bbox';
 import SymbolDraw from '../helper/SymbolDraw';
 import SymbolClz from '../helper/Symbol';
 import lineAnimationDiff from './lineAnimationDiff';
@@ -43,6 +42,8 @@ import type Axis2D from '../../coord/cartesian/Axis2D';
 import { CoordinateSystemClipArea } from '../../coord/CoordinateSystem';
 import { setStatesStylesFromModel, setStatesFlag, enableHoverEmphasis } from '../../util/states';
 import { getECData } from '../../util/ecData';
+import { createFloat32Array } from '../../util/vendor';
+import { createSymbol } from '../../util/symbol';
 
 
 type PolarArea = ReturnType<Polar['getArea']>;
@@ -52,29 +53,46 @@ interface SymbolExtended extends SymbolClz {
     __temp: boolean
 }
 
-function isPointsSame(points1: number[][], points2: number[][]) {
+function isPointsSame(points1: ArrayLike<number>, points2: ArrayLike<number>) {
     if (points1.length !== points2.length) {
         return;
     }
     for (let i = 0; i < points1.length; i++) {
-        const p1 = points1[i];
-        const p2 = points2[i];
-        if (p1[0] !== p2[0] || p1[1] !== p2[1]) {
+        if (points1[i] !== points2[i]) {
             return;
         }
     }
     return true;
 }
 
-function getBoundingDiff(points1: number[][], points2: number[][]): number {
-    const min1 = [] as number[];
-    const max1 = [] as number[];
+function bboxFromPoints(points: ArrayLike<number>) {
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
 
-    const min2 = [] as number[];
-    const max2 = [] as number[];
+    for (let i = 0; i < points.length;) {
+        const x = points[i++];
+        const y = points[i++];
+        if (!isNaN(x)) {
+            minX = Math.min(x, minX);
+            maxX = Math.max(x, maxX);
+        }
+        if (!isNaN(y)) {
+            minY = Math.min(y, minY);
+            maxY = Math.max(y, maxY);
+        }
+    }
+    return [
+        [minX, minY],
+        [maxX, maxY]
+    ];
+}
 
-    fromPoints(points1, min1, max1);
-    fromPoints(points2, min2, max2);
+function getBoundingDiff(points1: ArrayLike<number>, points2: ArrayLike<number>): number {
+
+    const [min1, max1] = bboxFromPoints(points1);
+    const [min2, max2] = bboxFromPoints(points2);
 
     // Get a max value from each corner of two boundings.
     return Math.max(
@@ -99,56 +117,61 @@ function getStackedOnPoints(
         return [];
     }
 
-    const points = [];
-    for (let idx = 0, len = data.count(); idx < len; idx++) {
-        points.push(getStackedOnPoint(dataCoordInfo, coordSys, data, idx));
+    const len = data.count();
+    const points = createFloat32Array(len * 2);
+    for (let idx = 0; idx < len; idx++) {
+        const pt = getStackedOnPoint(dataCoordInfo, coordSys, data, idx);
+        points[idx * 2] = pt[0];
+        points[idx * 2 + 1] = pt[1];
     }
 
     return points;
 }
 
 function turnPointsIntoStep(
-    points: number[][],
+    points: ArrayLike<number>,
     coordSys: Cartesian2D | Polar,
     stepTurnAt: 'start' | 'end' | 'middle'
-) {
+): number[] {
     const baseAxis = coordSys.getBaseAxis();
     const baseIndex = baseAxis.dim === 'x' || baseAxis.dim === 'radius' ? 0 : 1;
 
-    const stepPoints = [];
+    const stepPoints: number[] = [];
     let i = 0;
-    for (; i < points.length - 1; i++) {
-        const nextPt = points[i + 1];
-        const pt = points[i];
-        stepPoints.push(pt);
+    const stepPt: number[] = [];
+    const pt: number[] = [];
+    const nextPt: number[] = [];
+    for (; i < points.length - 2; i += 2) {
+        nextPt[0] = points[i + 2];
+        nextPt[1] = points[i + 3];
+        pt[0] = points[i];
+        pt[1] = points[i + 1];
+        stepPoints.push(pt[0], pt[1]);
 
-        const stepPt = [];
         switch (stepTurnAt) {
             case 'end':
                 stepPt[baseIndex] = nextPt[baseIndex];
                 stepPt[1 - baseIndex] = pt[1 - baseIndex];
-                // default is start
-                stepPoints.push(stepPt);
+                stepPoints.push(stepPt[0], stepPt[1]);
                 break;
             case 'middle':
-                // default is start
                 const middle = (pt[baseIndex] + nextPt[baseIndex]) / 2;
                 const stepPt2 = [];
                 stepPt[baseIndex] = stepPt2[baseIndex] = middle;
                 stepPt[1 - baseIndex] = pt[1 - baseIndex];
                 stepPt2[1 - baseIndex] = nextPt[1 - baseIndex];
-                stepPoints.push(stepPt);
-                stepPoints.push(stepPt2);
+                stepPoints.push(stepPt[0], stepPt[1]);
+                stepPoints.push(stepPt2[0], stepPt[1]);
                 break;
             default:
+                // default is start
                 stepPt[baseIndex] = pt[baseIndex];
                 stepPt[1 - baseIndex] = nextPt[1 - baseIndex];
-                // default is start
-                stepPoints.push(stepPt);
+                stepPoints.push(stepPt[0], stepPt[1]);
         }
     }
     // Last points
-    points[i] && stepPoints.push(points[i]);
+    stepPoints.push(points[i++], points[i++]);
     return stepPoints;
 }
 
@@ -365,8 +388,8 @@ class LineView extends ChartView {
     _polyline: ECPolyline;
     _polygon: ECPolygon;
 
-    _stackedOnPoints: number[][];
-    _points: number[][];
+    _stackedOnPoints: ArrayLike<number>;
+    _points: ArrayLike<number>;
 
     _step: LineSeriesOption['step'];
     _valueOrigin: LineSeriesOption['areaStyle']['origin'];
@@ -392,7 +415,7 @@ class LineView extends ChartView {
         const lineStyleModel = seriesModel.getModel('lineStyle');
         const areaStyleModel = seriesModel.getModel('areaStyle');
 
-        let points = data.mapArray(data.getItemLayout);
+        let points = data.getLayout('points') as number[] || [];
 
         const isCoordSysPolar = coordSys.type === 'polar';
         const prevCoordSys = this._coordSys;
@@ -458,7 +481,10 @@ class LineView extends ChartView {
         ) {
             showSymbol && symbolDraw.updateData(data, {
                 isIgnore: isIgnoreFunc,
-                clipShape: clipShapeForSymbol
+                clipShape: clipShapeForSymbol,
+                getSymbolPoint(idx) {
+                    return [points[idx * 2], points[idx * 2 + 1]];
+                }
             });
 
             if (step) {
@@ -495,7 +521,10 @@ class LineView extends ChartView {
             // because points are not changed
             showSymbol && symbolDraw.updateData(data, {
                 isIgnore: isIgnoreFunc,
-                clipShape: clipShapeForSymbol
+                clipShape: clipShapeForSymbol,
+                getSymbolPoint(idx) {
+                    return [points[idx * 2], points[idx * 2 + 1]];
+                }
             });
 
             // Stop symbol animation and sync with line points
@@ -629,25 +658,27 @@ class LineView extends ChartView {
         this._changePolyState('emphasis');
 
         if (!(dataIndex instanceof Array) && dataIndex != null && dataIndex >= 0) {
+            const points = data.getLayout('points');
             let symbol = data.getItemGraphicEl(dataIndex) as SymbolClz;
             if (!symbol) {
                 // Create a temporary symbol if it is not exists
-                const pt = data.getItemLayout(dataIndex) as number[];
-                if (!pt) {
+                const x = points[dataIndex * 2];
+                const y = points[dataIndex * 2 + 1];
+                if (isNaN(x) || isNaN(y)) {
                     // Null data
                     return;
                 }
                 // fix #11360: should't draw symbol outside clipShapeForSymbol
-                if (this._clipShapeForSymbol && !this._clipShapeForSymbol.contain(pt[0], pt[1])) {
+                if (this._clipShapeForSymbol && !this._clipShapeForSymbol.contain(x, y)) {
                     return;
                 }
                 symbol = new SymbolClz(data, dataIndex);
-                symbol.setPosition(pt);
+                symbol.x = x;
+                symbol.y = y;
                 symbol.setZ(
                     seriesModel.get('zlevel'),
                     seriesModel.get('z')
                 );
-                symbol.ignore = isNaN(pt[0]) || isNaN(pt[1]);
                 (symbol as SymbolExtended).__temp = true;
                 data.setItemGraphicEl(dataIndex, symbol);
 
@@ -705,7 +736,7 @@ class LineView extends ChartView {
         polygon && setStatesFlag(polygon, toState);
     }
 
-    _newPolyline(points: number[][]) {
+    _newPolyline(points: ArrayLike<number>) {
         let polyline = this._polyline;
         // Remove previous created polyline
         if (polyline) {
@@ -714,7 +745,7 @@ class LineView extends ChartView {
 
         polyline = new ECPolyline({
             shape: {
-                points: points
+                points
             },
             segmentIgnoreThreshold: 2,
             z2: 10
@@ -727,7 +758,7 @@ class LineView extends ChartView {
         return polyline;
     }
 
-    _newPolygon(points: number[][], stackedOnPoints: number[][]) {
+    _newPolygon(points: ArrayLike<number>, stackedOnPoints: ArrayLike<number>) {
         let polygon = this._polygon;
         // Remove previous created polygon
         if (polygon) {
@@ -736,7 +767,7 @@ class LineView extends ChartView {
 
         polygon = new ECPolygon({
             shape: {
-                points: points,
+                points,
                 stackedOnPoints: stackedOnPoints
             },
             segmentIgnoreThreshold: 2
@@ -754,7 +785,7 @@ class LineView extends ChartView {
     // FIXME Two value axis
     _updateAnimation(
         data: List,
-        stackedOnPoints: number[][],
+        stackedOnPoints: ArrayLike<number>,
         coordSys: Cartesian2D | Polar,
         api: ExtensionAPI,
         step: LineSeriesOption['step'],
@@ -855,9 +886,12 @@ class LineView extends ChartView {
 
         if (polyline.animators && polyline.animators.length) {
             polyline.animators[0].during(function () {
+                const points = (polyline.shape as any).__points;
                 for (let i = 0; i < updatedDataInfo.length; i++) {
                     const el = updatedDataInfo[i].el;
-                    el.setPosition((polyline.shape as any).__points[updatedDataInfo[i].ptIdx]);
+                    const offset = updatedDataInfo[i].ptIdx * 2;
+                    el.x = points[offset];
+                    el.y = points[offset + 1];
                     el.markRedraw();
                 }
             });

--- a/src/chart/line/helper.ts
+++ b/src/chart/line/helper.ts
@@ -111,7 +111,7 @@ export function getStackedOnPoint(
     coordSys: Cartesian2D | Polar,
     data: List,
     idx: number
-    ) {
+) {
     let value = NaN;
     if (dataCoordInfo.stacked) {
         value = data.get(data.getCalculationInfo('stackedOverDimension'), idx) as number;

--- a/src/chart/line/poly.ts
+++ b/src/chart/line/poly.ts
@@ -56,7 +56,7 @@ function drawSegment(
     for (; k < segLen; k++) {
 
         const x = points[idx * 2];
-        const y = points[idx * 2 + dir];
+        const y = points[idx * 2 + 1];
 
         if (idx >= allLen || idx < 0) {
             break;
@@ -88,9 +88,11 @@ function drawSegment(
                 let nextIdx = idx + dir;
                 let nextX = points[nextIdx * 2];
                 let nextY = points[nextIdx * 2 + 1];
+                let tmpK = k + 1;
                 if (connectNulls) {
                     // Find next point not null
-                    while (isPointNull(nextX, nextY) && (nextIdx < (segLen + start)) || (dir < 0 && nextIdx >= start)) {
+                    while (isPointNull(nextX, nextY) && tmpK < segLen) {
+                        tmpK++;
                         nextIdx += dir;
                         nextX = points[nextIdx * 2];
                         nextY = points[nextIdx * 2 + 1];
@@ -101,7 +103,7 @@ function drawSegment(
                 let vx: number = 0;
                 let vy: number = 0;
                 // Is last point
-                if ((dir > 0 && nextIdx >= (segLen + start)) || (dir < 0 && nextIdx < start)) {
+                if (tmpK >= segLen || isPointNull(nextX, nextY)) {
                     cpx1 = x;
                     cpy1 = y;
                 }
@@ -228,19 +230,19 @@ export class ECPolyline extends Path<ECPolylineProps> {
         const points = shape.points;
 
         let i = 0;
-        let len = points.length;
+        let len = points.length / 2;
 
         const result = getBoundingBox(points, shape.smoothConstraint);
 
         if (shape.connectNulls) {
             // Must remove first and last null values avoid draw error in polygon
-            for (; len > 0; len -= 2) {
-                if (!isPointNull(points[len - 2], points[len - 1])) {
+            for (; len > 0; len--) {
+                if (!isPointNull(points[len * 2 - 2], points[len * 2 - 1])) {
                     break;
                 }
             }
-            for (; i < len; i += 2) {
-                if (!isPointNull(points[i], points[i + 1])) {
+            for (; i < len; i++) {
+                if (!isPointNull(points[i * 2], points[i * 2 + 1])) {
                     break;
                 }
             }
@@ -282,20 +284,20 @@ export class ECPolygon extends Path {
         const stackedOnPoints = shape.stackedOnPoints;
 
         let i = 0;
-        let len = points.length;
+        let len = points.length / 2;
         const smoothMonotone = shape.smoothMonotone;
         const bbox = getBoundingBox(points, shape.smoothConstraint);
         const stackedOnBBox = getBoundingBox(stackedOnPoints, shape.smoothConstraint);
 
         if (shape.connectNulls) {
             // Must remove first and last null values avoid draw error in polygon
-            for (; len > 0; len -= 2) {
-                if (!isPointNull(points[len - 2], points[len - 1])) {
+            for (; len > 0; len--) {
+                if (!isPointNull(points[len * 2 - 2], points[len * 2 - 1])) {
                     break;
                 }
             }
-            for (; i < len; i += 2) {
-                if (!isPointNull(points[i], points[i + 1])) {
+            for (; i < len; i++) {
+                if (!isPointNull(points[i * 2], points[i * 2 + 1])) {
                     break;
                 }
             }
@@ -313,7 +315,7 @@ export class ECPolygon extends Path {
             );
             i += k + 1;
 
-            // ctx.closePath();
+            ctx.closePath();
         }
     }
 }

--- a/src/chart/scatter/ScatterView.ts
+++ b/src/chart/scatter/ScatterView.ts
@@ -84,7 +84,7 @@ class ScatterView extends ChartView {
             };
         }
         else {
-            const res = pointsLayout().reset(seriesModel, ecModel, api) as StageHandlerProgressExecutor;
+            const res = pointsLayout('').reset(seriesModel, ecModel, api) as StageHandlerProgressExecutor;
             if (res.progress) {
                 res.progress({ start: 0, end: data.count(), count: data.count() }, data);
             }

--- a/src/chart/themeRiver/ThemeRiverView.ts
+++ b/src/chart/themeRiver/ThemeRiverView.ts
@@ -77,8 +77,8 @@ class ThemeRiverView extends ChartView {
                 group.remove(oldLayersGroups[idx]);
                 return;
             }
-            const points0 = [];
-            const points1 = [];
+            const points0: number[] = [];
+            const points1: number[] = [];
             let style;
             const indices = layersSeries[idx].indices;
             let j = 0;
@@ -88,8 +88,8 @@ class ThemeRiverView extends ChartView {
                 const y0 = layout.y0;
                 const y = layout.y;
 
-                points0.push([x, y0]);
-                points1.push([x, y0 + y]);
+                points0.push(x, y0);
+                points1.push(x, y0 + y);
 
                 style = data.getItemVisual(indices[j], 'style');
             }

--- a/src/coord/cartesian/Cartesian2D.ts
+++ b/src/coord/cartesian/Cartesian2D.ts
@@ -106,12 +106,13 @@ class Cartesian2D extends Cartesian<Axis2D> implements CoordinateSystem {
     }
 
     dataToPoint(data: ScaleDataValue[], reserved?: unknown, out?: number[]): number[] {
-        if (this._transform) {
-            return applyTransform(out || [], data as number[], this._transform);
+        out = out || [];
+        if (this._transform && !isNaN(data[0] as number) && !isNaN(data[1] as number)) {
+            // Fast path
+            return applyTransform(out, data as number[], this._transform);
         }
         const xAxis = this.getAxis('x');
         const yAxis = this.getAxis('y');
-        out = out || [];
         out[0] = xAxis.toGlobalCoord(xAxis.dataToCoord(data[0]));
         out[1] = yAxis.toGlobalCoord(yAxis.dataToCoord(data[1]));
         return out;

--- a/src/coord/cartesian/Cartesian2D.ts
+++ b/src/coord/cartesian/Cartesian2D.ts
@@ -139,12 +139,12 @@ class Cartesian2D extends Cartesian<Axis2D> implements CoordinateSystem {
     }
 
     pointToData(point: number[], out?: number[]): number[] {
+        out = out || [];
         if (this._invTransform) {
             return applyTransform(out, point, this._invTransform);
         }
         const xAxis = this.getAxis('x');
         const yAxis = this.getAxis('y');
-        out = out || [];
         out[0] = xAxis.coordToData(xAxis.toLocalCoord(point[0]));
         out[1] = yAxis.coordToData(yAxis.toLocalCoord(point[1]));
         return out;

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -152,6 +152,12 @@ class Grid implements CoordinateSystemMaster {
             adjustAxes();
         }
 
+        each(this._coordsList, function (coord) {
+            // Calculate affine matrix to accelerate the data to point transform.
+            // If all the axes scales are time or value.
+            coord.calcAffineTransform();
+        });
+
         function adjustAxes() {
             each(axesList, function (axis) {
                 const isHorizontal = axis.isHorizontal();
@@ -407,10 +413,6 @@ class Grid implements CoordinateSystemMaster {
      * Update cartesian properties from series.
      */
     private _updateScale(ecModel: GlobalModel, gridModel: GridModel): void {
-        const sortedDataValue: number[] = [];
-        const sortedDataIndex: number[] = [];
-        let hasCategoryIndices = false;
-
         // Reset scale
         each(this._axesList, function (axis) {
             axis.scale.setExtent(Infinity, -Infinity);

--- a/src/data/List.ts
+++ b/src/data/List.ts
@@ -749,24 +749,6 @@ class List<
 
         const chunkStore = storage[dim][chunkIndex];
         const value = chunkStore[chunkOffset];
-        // FIXME ordinal data type is not stackable
-        // if (stack) {
-        //     let dimensionInfo = this._dimensionInfos[dim];
-        //     if (dimensionInfo && dimensionInfo.stackable) {
-        //         let stackedOn = this.stackedOn;
-        //         while (stackedOn) {
-        //             // Get no stacked data of stacked on
-        //             let stackedValue = stackedOn.get(dim, idx);
-        //             // Considering positive stack, negative stack and empty data
-        //             if ((value >= 0 && stackedValue > 0)  // Positive stack
-        //                 || (value <= 0 && stackedValue < 0) // Negative stack
-        //             ) {
-        //                 value += stackedValue;
-        //             }
-        //             stackedOn = stackedOn.stackedOn;
-        //         }
-        //     }
-        // }
 
         return value;
     }

--- a/src/data/helper/dataProvider.ts
+++ b/src/data/helper/dataProvider.ts
@@ -158,9 +158,11 @@ export class DefaultDataProvider implements DataProvider {
         ): ArrayLike<number> {
             idx = idx - this._offset;
             out = out || [];
-            const offset = this._dimSize * idx;
-            for (let i = 0; i < this._dimSize; i++) {
-                out[i] = (this._data as ArrayLike<number>)[offset + i];
+            const data = this._data;
+            const dimSize = this._dimSize;
+            const offset = dimSize * idx;
+            for (let i = 0; i < dimSize; i++) {
+                out[i] = (data as ArrayLike<number>)[offset + i];
             }
             return out;
         };

--- a/src/layout/points.ts
+++ b/src/layout/points.ts
@@ -56,8 +56,8 @@ export default function (seriesType: string, forceStoreInTypedArray?: boolean): 
                 dims[1] = stackResultDim;
             }
 
-            const dimInfo0 = data.getDimensionInfo(0);
-            const dimInfo1 = data.getDimensionInfo(1);
+            const dimInfo0 = data.getDimensionInfo(dims[0]);
+            const dimInfo1 = data.getDimensionInfo(dims[1]);
 
             const dimIdx0 = dimInfo0 && dimInfo0.index;
             const dimIdx1 = dimInfo1 && dimInfo1.index;
@@ -75,21 +75,21 @@ export default function (seriesType: string, forceStoreInTypedArray?: boolean): 
 
                         if (dimLen === 1) {
                             const x = data.getByDimIdx(dimIdx0, i) as ParsedValueNumeric;
-                            point = !isNaN(x) && coordSys.dataToPoint(x, null, tmpOut);
+                            point = coordSys.dataToPoint(x, 0, tmpOut);
                         }
                         else {
-                            const x = tmpIn[0] = data.getByDimIdx(dimIdx0, i) as ParsedValueNumeric;
-                            const y = tmpIn[1] = data.getByDimIdx(dimIdx1, i) as ParsedValueNumeric;
-                            // Also {Array.<number>}, not undefined to avoid if...else... statement
-                            point = !isNaN(x) && !isNaN(y) && coordSys.dataToPoint(tmpIn, null, tmpOut);
+                            tmpIn[0] = data.getByDimIdx(dimIdx0, i) as ParsedValueNumeric;
+                            tmpIn[1] = data.getByDimIdx(dimIdx1, i) as ParsedValueNumeric;
+                            // Let coordinate system to handle the NaN data.
+                            point = coordSys.dataToPoint(tmpIn, 0, tmpOut);
                         }
 
                         if (useTypedArray) {
-                            points[offset++] = point ? point[0] : NaN;
-                            points[offset++] = point ? point[1] : NaN;
+                            points[offset++] = point[0];
+                            points[offset++] = point[1];
                         }
                         else {
-                            data.setItemLayout(i, (point && point.slice()) || [NaN, NaN]);
+                            data.setItemLayout(i, point.slice());
                         }
                     }
 

--- a/src/layout/points.ts
+++ b/src/layout/points.ts
@@ -56,6 +56,11 @@ export default function (seriesType: string, forceStoreInTypedArray?: boolean): 
                 dims[1] = stackResultDim;
             }
 
+            const dimInfo0 = data.getDimensionInfo(0);
+            const dimInfo1 = data.getDimensionInfo(1);
+
+            const dimIdx0 = dimInfo0 && dimInfo0.index;
+            const dimIdx1 = dimInfo1 && dimInfo1.index;
 
             return dimLen && {
                 progress(params, data) {
@@ -64,16 +69,17 @@ export default function (seriesType: string, forceStoreInTypedArray?: boolean): 
 
                     const tmpIn: ParsedValueNumeric[] = [];
                     const tmpOut: number[] = [];
+
                     for (let i = params.start, offset = 0; i < params.end; i++) {
                         let point;
 
                         if (dimLen === 1) {
-                            const x = data.get(dims[0], i) as ParsedValueNumeric;
+                            const x = data.getByDimIdx(dimIdx0, i) as ParsedValueNumeric;
                             point = !isNaN(x) && coordSys.dataToPoint(x, null, tmpOut);
                         }
                         else {
-                            const x = tmpIn[0] = data.get(dims[0], i) as ParsedValueNumeric;
-                            const y = tmpIn[1] = data.get(dims[1], i) as ParsedValueNumeric;
+                            const x = tmpIn[0] = data.getByDimIdx(dimIdx0, i) as ParsedValueNumeric;
+                            const y = tmpIn[1] = data.getByDimIdx(dimIdx1, i) as ParsedValueNumeric;
                             // Also {Array.<number>}, not undefined to avoid if...else... statement
                             point = !isNaN(x) && !isNaN(y) && coordSys.dataToPoint(tmpIn, null, tmpOut);
                         }

--- a/src/scale/Scale.ts
+++ b/src/scale/Scale.ts
@@ -97,6 +97,8 @@ abstract class Scale {
 
     /**
      * Get extent
+     *
+     * Extent is always in increase order.
      */
     getExtent(): [number, number] {
         return this._extent.slice() as [number, number];

--- a/src/scale/Time.ts
+++ b/src/scale/Time.ts
@@ -232,7 +232,7 @@ class TimeScale extends IntervalScale {
 
     parse(val: number | string | Date): number {
         // val might be float.
-        return +numberUtil.parseDate(val);
+        return typeof val === 'number' ? val : +numberUtil.parseDate(val);
     }
 
     contain(val: number): boolean {

--- a/src/util/vendor.ts
+++ b/src/util/vendor.ts
@@ -17,21 +17,18 @@
 * under the License.
 */
 
-import * as echarts from '../echarts';
+import { isArray } from 'zrender/src/core/util';
 
-import './line/LineSeries';
-import './line/LineView';
+/* global Float32Array */
+const supportFloat32Array = typeof Float32Array !== 'undefined';
 
-import layoutPoints from '../layout/points';
-import dataSample from '../processor/dataSample';
+const Float32ArrayCtor = !supportFloat32Array ? Array : Float32Array;
 
-// In case developer forget to include grid component
-import '../component/gridSimple';
-
-echarts.registerLayout(layoutPoints('line', true));
-
-// Down sample after filter
-echarts.registerProcessor(
-    echarts.PRIORITY.PROCESSOR.STATISTIC,
-    dataSample('line')
-);
+export function createFloat32Array(arg: number | number[]): number[] | Float32Array {
+    if (isArray(arg)) {
+        // Return self directly if don't support TypedArray.
+        return supportFloat32Array ? new Float32Array(arg) : arg;
+    }
+    // Else is number
+    return new Float32ArrayCtor(arg);
+}

--- a/test/area-smooth.html
+++ b/test/area-smooth.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+
+
+
+        <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+            var option;
+            // $.getJSON('./data/nutrients.json', function (data) {});
+
+            option = {
+                xAxis: {
+                    type: 'time'
+                },
+                yAxis: {
+                    type: 'value',
+                    boundaryGap: [0, '100%']
+                },
+                series: [
+                    {
+                        name: '模拟数据',
+                        type: 'line',
+                        smooth: true,
+                        // areaStyle: {},
+                        data: [
+                            [Date.UTC(1970, 9, 29), 0],
+                            [Date.UTC(1970, 10, 9), 0],
+                            [Date.UTC(1970, 11, 1), 6],
+                            [Date.UTC(1971, 0, 1), 6],
+                            [Date.UTC(1971, 0, 10), 6],
+                            [Date.UTC(1971, 1, 19), 0],
+                            [Date.UTC(1971, 2, 25), 0],
+                            [Date.UTC(1971, 3, 19), 3],
+                            [Date.UTC(1971, 3, 30), 3],
+                            [Date.UTC(1971, 4, 14), 3],
+                            [Date.UTC(1971, 4, 24), 0],
+                            [Date.UTC(1971, 5, 10), 0]
+                        ]
+                    }
+                ]
+            };
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Case from https://github.com/apache/incubator-echarts/issues/4556'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+

--- a/test/largeLine.html
+++ b/test/largeLine.html
@@ -64,7 +64,7 @@ under the License.
                         show: true,
                         realtime: true,
                         // showDataShadow: false,
-                        start: 50,
+                        start: 10,
                         end: 60
                     }],
                     xAxis : [
@@ -88,22 +88,20 @@ under the License.
                     }
                 };
 
-                var date = [];
+                var date = new Float64Array(pointCount)
                 var oneDay = 24 * 3600 * 1000;
-                var base = +new Date(1897, 9, 3);
+                var base = +new Date(1987, 9, 3);
                 for (var j = 0; j < pointCount; j++) {
-                    date.push(base += oneDay);
+                    date[j] = base += oneDay;
                 }
                 for (var i = 0; i < lineCount; i++) {
                     var y = Math.random() * 1000;
-                    var values = [];
+                    var values = new Float64Array(pointCount * 2);
+                    var off = 0;
                     for (var j = 0; j < pointCount; j++) {
                         y += Math.round(10 + Math.random() * (-10 - 10));
-                        values.push(
-                            date[j],
-                            // Math.random() < 0.1 ? '-' : y
-                            y
-                        );
+                        values[off++] = date[j];
+                        values[off++] = y;
                     }
 
                   option.legend.data.push( 'line' + i );
@@ -117,13 +115,14 @@ under the License.
                         x: 'date',
                         y: 'value'
                     },
-                    data: new Float64Array(values),
+                    data: values,
                     lineStyle: lineStyle
                   });
                 }
 
                 function refresh(isBtnRefresh){
                     var start = new Date();
+                    console.profile('render');
                     for( var n = 0; n < chartCount; n++ ) {
                         var el = document.createElement('div');
                       el.innerHTML = '<h1>'+n+'</h1><div id="chart'+n+'" style="width: 860px; height: 320px"></div>';
@@ -132,6 +131,7 @@ under the License.
                       myChart = echarts.init(document.getElementById('chart'+n));
                       myChart.setOption(option, true);
                     }
+                    console.profileEnd('render');
                     setTimeout(function () {
                         var end = new Date();
                         document.getElementById('timing').innerHTML = 'Graphs loaded in ' + ( end - start ) + ' ms.';

--- a/test/largeLine.html
+++ b/test/largeLine.html
@@ -47,8 +47,8 @@ under the License.
             ], function (echarts) {
                 var myChart;
                 var lineCount = 20;
-                var pointCount = 1000;
-                var chartCount = 50;
+                var pointCount = 10000;
+                var chartCount = 20;
 
                 var option = {
                     tooltip : {
@@ -92,8 +92,7 @@ under the License.
                 var oneDay = 24 * 3600 * 1000;
                 var base = +new Date(1897, 9, 3);
                 for (var j = 0; j < pointCount; j++) {
-                    var now = new Date(base += oneDay);
-                    date.push([now.getFullYear(), now.getMonth() + 1, now.getDate()].join('-'));
+                    date.push(base += oneDay);
                 }
                 for (var i = 0; i < lineCount; i++) {
                     var y = Math.random() * 1000;
@@ -101,11 +100,9 @@ under the License.
                     for (var j = 0; j < pointCount; j++) {
                         y += Math.round(10 + Math.random() * (-10 - 10));
                         values.push(
-                            [
-                                date[j],
-                                // Math.random() < 0.1 ? '-' : y
-                                y
-                            ]
+                            date[j],
+                            // Math.random() < 0.1 ? '-' : y
+                            y
                         );
                     }
 
@@ -113,10 +110,14 @@ under the License.
                   option.series.push({
                     name: 'line' + i,
                     type: 'line',
-                    sampling: 'average',
                     hoverAnimation: false,
                     showSymbol: false,
-                    data: values,
+                    dimensions: ['date', 'value'],
+                    encode: {
+                        x: 'date',
+                        y: 'value'
+                    },
+                    data: new Float64Array(values),
                     lineStyle: lineStyle
                   });
                 }
@@ -131,9 +132,10 @@ under the License.
                       myChart = echarts.init(document.getElementById('chart'+n));
                       myChart.setOption(option, true);
                     }
-                    var end = new Date();
-
-                    document.getElementById('timing').innerHTML = 'Graphs loaded in ' + ( end - start ) + ' ms.';
+                    setTimeout(function () {
+                        var end = new Date();
+                        document.getElementById('timing').innerHTML = 'Graphs loaded in ' + ( end - start ) + ' ms.';
+                    });
                 };
 
                 refresh();


### PR DESCRIPTION
This pull request include two improvements to line series.

1. Reduce initial render time(and memory cost) up to 10x in the line series with millions of time series data.
2. Improve smooth result in some cases. 

### Details about performance improvement.

##### 1. Use TypedArray.

The most important thing did to improve the performance is to use TypedArray instead of normal array as much as possible. It will reduce the heap memory and GC cost significantly.

In this PR we use TypedArray to store the points of polyline and polygons. Also no `setItemLayout` anymore.

##### 2. Bake the transform of dataToPoint to matrix in Cartesian2D

It will simplify the transform to a very fast 6x2 multiply and add operations. But it only works for affine transform when axis type is `time` or `value`. So it's mainly for boosting the time series data.

##### 3. Remove unnecessary date parsing when it's a timestamp.

It can avoid creating millions of temporary `Date` object when parsing the time series data.

##### 5. Speed up storage access in List component.

It's a trick did for modern JS engine. I found the access of `storage` is slow when initializing millions of data in https://github.com/apache/incubator-echarts/blob/99ab1d7a2f1413ce38dd55d3808c4e434fe49ba8/src/data/List.ts#L628
I profiled it and saw `KeyedLoadIC_Megamorphic` in the profiling result, which means it's not a fast property access.

So we simplify the case to the following code.
```js
const obj = {};
obj.x = 1;
obj.y = 1;
function slowObjectAccess() {
    let sum = 0;
    for (let i = 0; i < 1e6; i++) {
        for (let k = 0; k < 2; k++) {
            const val = obj[k === 0 ? 'x' : 'y'];
            sum += val;
        }
    }
    return sum;
}

function fastObjectAccess() {
    let sum = 0;
    for (let i = 0; i < 1e6; i++) {
        for (let k = 0; k < 2; k++) {
            sum += k === 0 ? obj.x : obj.y;
        }
    }
    return sum;
}
```

And the test result shows `fastObjectAccess`can be 10x faster than `slowObjectAccess`. I can't find out why and how to avoid it because my limited knowledge of JS engine.  So I add an extra `_storageArr` array and get from this array in the hotspot code like `List#_initDataFromProvider`. It works well and the cost of `_initDataFromProvider ` reduced to half.

### Performance Result

#### Render time comparison between 4.x and 5.0

<img width="976" alt="infoflow 2020-09-20 12-01-40" src="https://user-images.githubusercontent.com/841551/93694107-73efed00-fb3a-11ea-97aa-6ed35c5bc6d9.png">

#### Heap memory comparison between 4.x and 5.0

<img width="998" alt="infoflow 2020-09-20 12-01-02" src="https://user-images.githubusercontent.com/841551/93694118-8ff38e80-fb3a-11ea-9733-bfa21f074f5c.png">

### Details about smooth improvement.

The original smooth algorithm will constraint the control points to the global bounding box. Which may lead to two issues as shown in the following picture.

<img width="1211" alt="infoflow 2020-09-18 22-43-12" src="https://user-images.githubusercontent.com/841551/93694597-59207700-fb40-11ea-958a-e79f485211a1.png">

So in this PR I did two changes.

1. Constraint the control points to the bounding box of two points locally.
2. Recalculate the previous control point after current control point is changed.

And the result after change.

<img width="1198" alt="infoflow 2020-09-18 22-42-06" src="https://user-images.githubusercontent.com/841551/93694130-c0d3c380-fb3a-11ea-94d6-2fe54d65bff1.png">


### Fixed issues

https://github.com/apache/incubator-echarts/issues/12249
https://github.com/apache/incubator-echarts/issues/10200
https://github.com/apache/incubator-echarts/issues/4556

