### PR TITLE
feat(tooltip): allow adding classes to tooltip DOM and migrate changes to next branch in #12834.

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -207,6 +207,12 @@ interface TooltipContentOption {
      *  some overflow clip but intrude outside of the container.
      */
     appendToBody: boolean
+
+    /**
+     * specified class name of tooltip dom
+     * @type {[type]}
+     */
+    className?: string
 }
 
 class TooltipHTMLContent {
@@ -245,6 +251,7 @@ class TooltipHTMLContent {
         const el = document.createElement('div');
         // TODO: TYPE
         (el as any).domBelongToZr = true;
+        opt.className && (el.className = opt.className);
         this.el = el;
         const zr = this._zr = api.getZr();
         const appendToBody = this._appendToBody = opt && opt.appendToBody;

--- a/src/component/tooltip/TooltipModel.ts
+++ b/src/component/tooltip/TooltipModel.ts
@@ -65,6 +65,12 @@ export interface TooltipOption extends CommonTooltipOption<TopLevelFormatterPara
      */
     appendToBody?: boolean
 
+    /**
+     * specified class name of tooltip dom
+     * Only available when renderMode is html
+     */
+    className?: string
+
     order?: TooltipOrderMode
 }
 

--- a/src/component/tooltip/TooltipRichContent.ts
+++ b/src/component/tooltip/TooltipRichContent.ts
@@ -32,6 +32,8 @@ class TooltipRichContent {
 
     private _show = false;
 
+    private _styleCoord: [number, number, number, number] = [0, 0, 0, 0];
+
     private _hideTimeout: number;
 
     private _enterable = true;
@@ -44,13 +46,15 @@ class TooltipRichContent {
 
     constructor(api: ExtensionAPI) {
         this._zr = api.getZr();
+        makeStyleCoord(this._styleCoord, this._zr, api.getWidth() / 2, api.getHeight() / 2);
     }
 
     /**
      * Update when tooltip is rendered
      */
-    update() {
-        // noop
+    update(tooltipModel: Model<TooltipOption>) {
+        const alwaysShowContent = tooltipModel.get('alwaysShowContent');
+        alwaysShowContent && this._moveIfResized();
     }
 
     show() {
@@ -136,6 +140,10 @@ class TooltipRichContent {
     moveTo(x: number, y: number) {
         const el = this.el;
         if (el) {
+            const styleCoord = this._styleCoord;
+            makeStyleCoord(styleCoord, this._zr, x, y);
+            x = styleCoord[0];
+            y = styleCoord[1];
             const style = el.style;
             const borderWidth = mathMaxWith0(style.borderWidth || 0);
             const shadowOuterSize = calcShadowOuterSize(style);
@@ -144,6 +152,22 @@ class TooltipRichContent {
             el.y = y + borderWidth + shadowOuterSize.top;
             el.markRedraw();
         }
+    }
+
+
+    /**
+     * when `alwaysShowContent` is true,
+     * move the tooltip after chart resized
+     */
+    _moveIfResized() {
+        // The ratio of left to width
+        const ratioX = this._styleCoord[2];
+        // The ratio of top to height
+        const ratioY = this._styleCoord[3];
+        this.moveTo(
+            ratioX * this._zr.getWidth(),
+            ratioY * this._zr.getHeight()
+        );
     }
 
     hide() {
@@ -157,7 +181,7 @@ class TooltipRichContent {
         if (this._show && !(this._inContent && this._enterable)) {
             if (time) {
                 this._hideDelay = time;
-                // Set show false to avoid invoke hideLater mutiple times
+                // Set show false to avoid invoke hideLater multiple times
                 this._show = false;
                 this._hideTimeout = setTimeout(zrUtil.bind(this.hide, this), time) as any;
             }
@@ -198,6 +222,13 @@ function calcShadowOuterSize(style: TextStyleProps) {
         top: mathMaxWith0(shadowBlur - shadowOffsetY),
         bottom: mathMaxWith0(shadowBlur + shadowOffsetY)
     };
+}
+
+function makeStyleCoord(out: number[], zr: ZRenderType, zrX: number, zrY: number) {
+    out[0] = zrX;
+    out[1] = zrY;
+    out[2] = out[0] / zr.getWidth();
+    out[3] = out[1] / zr.getHeight();
 }
 
 export default TooltipRichContent;

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -167,8 +167,7 @@ class TooltipView extends ComponentView {
         this._tooltipContent = this._renderMode === 'richText'
             ? new TooltipRichContent(api)
             : new TooltipHTMLContent(api.getDom(), api, {
-                appendToBody: tooltipModel.get('appendToBody', true),
-                className: tooltipModel.get('className', true)
+                appendToBody: tooltipModel.get('appendToBody', true)
             });
     }
 
@@ -197,7 +196,7 @@ class TooltipView extends ComponentView {
         this._alwaysShowContent = tooltipModel.get('alwaysShowContent');
 
         const tooltipContent = this._tooltipContent;
-        tooltipContent.update();
+        tooltipContent.update(tooltipModel);
         tooltipContent.setEnterable(tooltipModel.get('enterable'));
 
         this._initGlobalListener();
@@ -451,7 +450,7 @@ class TooltipView extends ComponentView {
     ) {
         // showDelay is used in this case: tooltip.enterable is set
         // as true. User intent to move mouse into tooltip and click
-        // something. `showDelay` makes it easyer to enter the content
+        // something. `showDelay` makes it easier to enter the content
         // but tooltip do not move immediately.
         const delay = tooltipModel.get('showDelay');
         cb = zrUtil.bind(cb, this);
@@ -667,7 +666,7 @@ class TooltipView extends ComponentView {
         const markupStyleCreator = new TooltipMarkupStyleCreator();
 
         // Do not check whether `trigger` is 'none' here, because `trigger`
-        // only works on cooridinate system. In fact, we have not found case
+        // only works on coordinate system. In fact, we have not found case
         // that requires setting `trigger` nothing on component yet.
 
         this._showOrMove(subTooltipModel, function (this: TooltipView) {

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -167,7 +167,8 @@ class TooltipView extends ComponentView {
         this._tooltipContent = this._renderMode === 'richText'
             ? new TooltipRichContent(api)
             : new TooltipHTMLContent(api.getDom(), api, {
-                appendToBody: tooltipModel.get('appendToBody', true)
+                appendToBody: tooltipModel.get('appendToBody', true),
+                className: tooltipModel.get('className', true)
             });
     }
 

--- a/test/tooltip-windowResize.html
+++ b/test/tooltip-windowResize.html
@@ -40,6 +40,18 @@ under the License.
             margin: 0 auto;
         }
 
+        .custoized-tooltip-class {
+            background-color: cyan!important;
+            text-shadow: 0 0 5px red;
+        }
+        .custoized-tooltip-class::after {
+            content: 'pseudo after';
+            display: inline-block;
+            position: absolute;
+            left: 110%;
+            top: 50%;
+            transform: translateY(-50%);
+        }
     </style>
 
 
@@ -203,12 +215,34 @@ under the License.
             };
 
             var chart = testHelper.create(echarts, 'main0', {
-                option: option
+                option: option,
+                buttons: [
+                    {
+                        text: 'add class',
+                        onclick: function () {
+                            chart.setOption({
+                                tooltip: {
+                                    className: 'custoized-tooltip-class'
+                                }
+                            })
+                        }
+                    },
+                    {
+                        text: 'recovery class',
+                        onclick: function () {
+                            chart.setOption({
+                                tooltip: {
+                                    className: ''
+                                }
+                            })
+                        }
+                    }
+                ]
             });
             chart.setOption(option, true);
-            window.addEventListener('resize',function () {
+            window.addEventListener('resize', function () {
                 chart.resize();
-            })
+            });
         });
 
     </script>
@@ -372,9 +406,9 @@ under the License.
                 option: option
             });
             chart.setOption(option, true);
-            window.addEventListener('resize',function () {
+            window.addEventListener('resize', function () {
                 chart.resize();
-            })
+            });
         });
 
     </script>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [x] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

- Allow users to add some classes to the tooltip dom to override default styles and get the dom by `document.getElementsByClassName`.
- Migrate changes in PR #12834 (relocate tooltip if chart resized)

### Fixed issues

NA.

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
The users cannot set some styles by className.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
The users can override some styles by specifying className.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/26999792/94902491-d1852180-04ca-11eb-93de-6f9f7911e10e.png)
![image](https://user-images.githubusercontent.com/26999792/94907192-5889c800-04d2-11eb-85fd-a62314ffc341.png)

## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->
Add a new option `className` to `tooltip` component.

### Related test cases or examples to use the new APIs

Please refer to `test/tooltip-windowResize.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
