### PR TITLE
[5.0] [Feature] sunburst series supports cornerRadius

### DIFF
--- a/src/chart/sunburst/SunburstSeries.ts
+++ b/src/chart/sunburst/SunburstSeries.ts
@@ -111,6 +111,16 @@ export interface SunburstSeriesOption extends
     animationType?: 'expansion' | 'scale'
 
     sort?: 'desc' | 'asc' | ((a: TreeNode, b: TreeNode) => number)
+
+    // can be 10
+    // which means that both innerCornerRadius and outerCornerRadius are 10
+    // can also be an array [20, 10]
+    // which means that innerCornerRadius is 20
+    // and outerCornerRadius is 10
+    // can also be a string or string array, such as ['20%', '50%']
+    // which means that innerCornerRadius is 20% of the innerRadius
+    // and outerCornerRadius is half of outerRadius.
+    cornerRadius?: (number | string)[] | number | string
 }
 
 interface SunburstSeriesModel {
@@ -177,6 +187,7 @@ class SunburstSeriesModel extends SeriesModel<SunburstSeriesOption> {
         // 默认全局居中
         center: ['50%', '50%'],
         radius: [0, '75%'],
+        cornerRadius: 0,
         // 默认顺时针
         clockwise: true,
         startAngle: 90,

--- a/src/chart/sunburst/sunburstLayout.ts
+++ b/src/chart/sunburst/sunburstLayout.ts
@@ -35,12 +35,16 @@ export default function (
     ecModel.eachSeriesByType(seriesType, function (seriesModel: SunburstSeriesModel) {
         let center = seriesModel.get('center');
         let radius = seriesModel.get('radius');
+        let cornerRadius = seriesModel.get('cornerRadius');
 
         if (!zrUtil.isArray(radius)) {
             radius = [0, radius];
         }
         if (!zrUtil.isArray(center)) {
             center = [center, center];
+        }
+        if (!zrUtil.isArray(cornerRadius)) {
+            cornerRadius = [cornerRadius, cornerRadius];
         }
 
         const width = api.getWidth();
@@ -50,6 +54,8 @@ export default function (
         const cy = parsePercent(center[1], height);
         const r0 = parsePercent(radius[0], size / 2);
         const r = parsePercent(radius[1], size / 2);
+        const innerCornerRadius = parsePercent(cornerRadius[0], r0);
+        const outerCornerRadius = parsePercent(cornerRadius[1], r);
 
         const startAngle = -seriesModel.get('startAngle') * RADIAN;
         const minAngle = seriesModel.get('minAngle') * RADIAN;
@@ -139,7 +145,9 @@ export default function (
                     cx: cx,
                     cy: cy,
                     r0: rStart,
-                    r: rEnd
+                    r: rEnd,
+                    cornerRadius: outerCornerRadius,
+                    innerCornerRadius: innerCornerRadius
                 });
             }
 
@@ -169,7 +177,9 @@ export default function (
                 cx: cx,
                 cy: cy,
                 r0: rStart,
-                r: rEnd
+                r: rEnd,
+                cornerRadius: outerCornerRadius,
+                innerCornerRadius: innerCornerRadius
             });
         }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Sunburst series supports corner radius in ECharts, please refer to #13123 & #13378 for more details.


### Fixed issues

- #13378 (partial)


## Details

![image](https://user-images.githubusercontent.com/26999792/95112431-804b8b00-0773-11eb-93a3-77d301859d1e.png)


## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->
Added a new option to the sunburst series.

- **cornerRadius** (can be a string/number/string array/number array)


### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information

 #13378 - Pie series supports cornerRadius
fe0d94a - Treemap series supports borderRadius 