### PR TITLE
fix(extension/bmap): fix bmap first layout may be incorrect if container's layout is flex or grid.(#13424)

### DIFF
--- a/extension-src/bmap/BMapCoordSys.ts
+++ b/extension-src/bmap/BMapCoordSys.ts
@@ -177,9 +177,9 @@ BMapCoordSys.create = function (ecModel, api) {
                 root.removeChild(bmapRoot);
             }
             bmapRoot = document.createElement('div');
-            bmapRoot.style.cssText = 'width:100%;height:100%';
-            // Not support IE8
-            bmapRoot.classList.add('ec-extension-bmap');
+            bmapRoot.className = 'ec-extension-bmap';
+            // fix #13424
+            bmapRoot.style.cssText = 'position:absolute;width:100%;height:100%';
             root.appendChild(bmapRoot);
 
             // initializes bmap

--- a/extension-src/bmap/BMapView.ts
+++ b/extension-src/bmap/BMapView.ts
@@ -47,8 +47,16 @@ export default echarts.extendComponentView({
                 -parseInt(offsetEl.style.left, 10) || 0,
                 -parseInt(offsetEl.style.top, 10) || 0
             ];
-            viewportRoot.style.left = mapOffset[0] + 'px';
-            viewportRoot.style.top = mapOffset[1] + 'px';
+            // only update style when map offset changed
+            const viewportRootStyle = viewportRoot.style;
+            const offsetLeft = mapOffset[0] + 'px';
+            const offsetTop = mapOffset[1] + 'px';
+            if (viewportRootStyle.left !== offsetLeft) {
+                viewportRootStyle.left = offsetLeft;
+            }
+            if (viewportRootStyle.top !== offsetTop) {
+                viewportRootStyle.top = offsetTop;
+            }
 
             coordSys.setMapOffset(mapOffset);
             bMapModel.__mapOffset = mapOffset;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix #13424, add absolute position to echarts bmap container.


### Fixed issues

- #13424


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/26999792/95949931-4559ef00-0e26-11eb-82fb-22f9bcd0ec5c.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/26999792/95950321-de890580-0e26-11eb-8005-fd56599603aa.png)



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

Please refer to this demo https://codepen.io/plainheart/pen/ZEbdRdr



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
