### PR TITLE
Fix(legend.scroll): scroll animation start position was incorrect

### DIFF
--- a/src/component/legend/ScrollableLegendView.ts
+++ b/src/component/legend/ScrollableLegendView.ts
@@ -295,7 +295,6 @@ class ScrollableLegendView extends LegendView {
         // Always align controller to content as 'middle'.
         controllerPos[1 - orientIdx] += contentRect[hw] / 2 - controllerRect[hw] / 2;
 
-        contentGroup.setPosition(contentPos);
         containerGroup.setPosition(containerPos);
         controllerGroup.setPosition(controllerPos);
 

--- a/src/component/legend/ScrollableLegendView.ts
+++ b/src/component/legend/ScrollableLegendView.ts
@@ -205,7 +205,7 @@ class ScrollableLegendView extends LegendView {
         selector && (processMaxSize[wh] = maxSize[wh] - selectorRect[wh] - selectorButtonGap);
 
         const mainRect = this._layoutContentAndController(legendModel, isFirstRender,
-            processMaxSize, orientIdx, wh, hw, yx
+            processMaxSize, orientIdx, wh, hw, yx, xy
         );
 
         if (selector) {
@@ -238,7 +238,8 @@ class ScrollableLegendView extends LegendView {
         orientIdx: 0 | 1,
         wh: 'width' | 'height',
         hw: 'width' | 'height',
-        yx: 'x' | 'y'
+        yx: 'x' | 'y',
+        xy: 'y' | 'x'
     ) {
         const contentGroup = this.getContentGroup();
         const containerGroup = this._containerGroup;
@@ -264,12 +265,13 @@ class ScrollableLegendView extends LegendView {
         const controllerRect = controllerGroup.getBoundingRect();
         const showController = this._showController = contentRect[wh] > maxSize[wh];
 
+        // In case that the inner elements of contentGroup layout do not based on [0, 0]
         const contentPos = [-contentRect.x, -contentRect.y];
         // Remain contentPos when scroll animation perfroming.
         // If first rendering, `contentGroup.position` is [0, 0], which
         // does not make sense and may cause unexepcted animation if adopted.
         if (!isFirstRender) {
-            contentPos[orientIdx] = contentGroup[yx];
+            contentPos[orientIdx] = contentGroup[xy];
         }
 
         // Layout container group based on 0.
@@ -295,6 +297,7 @@ class ScrollableLegendView extends LegendView {
         // Always align controller to content as 'middle'.
         controllerPos[1 - orientIdx] += contentRect[hw] / 2 - controllerRect[hw] / 2;
 
+        contentGroup.setPosition(contentPos);
         containerGroup.setPosition(containerPos);
         controllerGroup.setPosition(controllerPos);
 

--- a/test/legend-scroll2plain.html
+++ b/test/legend-scroll2plain.html
@@ -40,6 +40,7 @@ under the License.
 
 
     <div id="main0"></div>
+    <div id="main1"></div>
 
 
 
@@ -134,11 +135,92 @@ under the License.
                 // buttons: [{text: 'btn-txt', onclick: function () {}}],
                 // recordCanvas: true,
             });
-
+            
             setTimeout(function () {
                 option.legend.type = 'plain';
                 chart.setOption(option);
             }, 3000);
+
+            var option1 = {
+                legend: {
+                    data: [
+                        '邮件营销', '联盟广告', '视频广告', '直接访问', '搜索引擎',
+                        '邮件营销1', '联盟广告1', '视频广告1', '直接访问1', '搜索引擎1'
+                    ],
+                    type: 'scroll'
+                },
+                xAxis: [{
+                    type: 'category',
+                    data: ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
+                }],
+                yAxis: [{
+                    type: 'value'
+                }],
+                series: [
+                    {
+                        name: '邮件营销',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '联盟广告',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '视频广告',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '直接访问',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '搜索引擎',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '邮件营销1',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '联盟广告1',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '视频广告1',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '直接访问1',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    },
+                    {
+                        name: '搜索引擎1',
+                        type: 'line',
+                        data: [null, null, null, null, null, null, null]
+                    }
+                ]
+                
+            };
+            var chart1 = testHelper.create(echarts, 'main1', {
+                title: [
+                    'Test Case Description of main1',
+                    'Legend scroll animation'
+                ],
+                option: option1,
+                width: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+            chart1.setOption(option1);
         });
     </script>
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix legend scroll animation always start at first element, even the page number wasn't 1.
The problem was that legend content group always reset position to first element before animation.


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?


![Kapture 2020-10-17 at 00 01 52](https://user-images.githubusercontent.com/20318608/96281516-02f20700-100c-11eb-9efb-410b70f7cbbd.gif)



### After: How is it fixed in this PR?

![Kapture 2020-10-16 at 23 57 00](https://user-images.githubusercontent.com/20318608/96281342-c8886a00-100b-11eb-9c11-c9fdf322b387.gif)




## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
