### PR TITLE
Allow passing of DOM nodes to setContent

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import { isString, indexOf, map, each, bind, isObject } from 'zrender/src/core/util';
+import { isString, indexOf, map, each, bind, isObject, isArray, isDom } from 'zrender/src/core/util';
 import { toHex } from 'zrender/src/tool/color';
 import { normalizeEvent } from 'zrender/src/core/event';
 import { transformLocalCoord } from 'zrender/src/core/dom';
@@ -375,20 +375,26 @@ class TooltipHTMLContent {
             return;
         }
 
+        const el = this.el;
+
         if (isString(arrowPosition) && tooltipModel.get('trigger') === 'item'
             && !shouldTooltipConfine(tooltipModel)) {
             content += assembleArrow(tooltipModel.get('backgroundColor'), borderColor, arrowPosition);
         }
-        if (isObject(content)) {
-            if (this.el.children) {
-                for (var child of Array.from(this.el.children)) {
-                    this.el.removeChild(child);
+        if (isString(content)) {
+            el.innerHTML = content == null ? '' : content;
+        }
+        else if (content) {
+            // Clear previous
+            el.innerHTML = '';
+            if (!isArray(content)) {
+                content = [content];
+            }
+            for (let i = 0; i < content.length; i++) {
+                if (isDom(content[i]) && content[i].parentNode !== el) {
+                    el.appendChild(content[i]);
                 }
             }
-            content.forEach(child => this.el.appendChild(child));
-        }
-        else {
-            this.el.innerHTML = content == null ? '' : content;
         }
     }
 

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import { isString, indexOf, map, each, bind } from 'zrender/src/core/util';
+import { isString, indexOf, map, each, bind, isObject } from 'zrender/src/core/util';
 import { toHex } from 'zrender/src/tool/color';
 import { normalizeEvent } from 'zrender/src/core/event';
 import { transformLocalCoord } from 'zrender/src/core/dom';
@@ -365,7 +365,7 @@ class TooltipHTMLContent {
     }
 
     setContent(
-        content: string,
+        content: string | HTMLElement[],
         markers: unknown,
         tooltipModel: Model<TooltipOption>,
         borderColor?: ZRColor,
@@ -379,8 +379,17 @@ class TooltipHTMLContent {
             && !shouldTooltipConfine(tooltipModel)) {
             content += assembleArrow(tooltipModel.get('backgroundColor'), borderColor, arrowPosition);
         }
-
-        this.el.innerHTML = content;
+        if (isObject(content)) {
+            if (this.el.children) {
+                for (var child of Array.from(this.el.children)) {
+                    this.el.removeChild(child);
+                }
+            }
+            content.forEach(child => this.el.appendChild(child));
+        }
+        else {
+            this.el.innerHTML = content == null ? '' : content;
+        }
     }
 
     setEnterable(enterable: boolean) {

--- a/src/component/tooltip/TooltipRichContent.ts
+++ b/src/component/tooltip/TooltipRichContent.ts
@@ -70,12 +70,15 @@ class TooltipRichContent {
      * Set tooltip content
      */
     setContent(
-        content: string,
+        content: string | HTMLElement[],
         markupStyleCreator: TooltipMarkupStyleCreator,
         tooltipModel: Model<TooltipOption>,
         borderColor: ZRColor,
         arrowPosition: TooltipOption['position']
     ) {
+        if (zrUtil.isObject(content)) {
+            throw new Error("Passing DOM nodes as content is not supported in richText tooltip!");
+        }
         if (this.el) {
             this._zr.remove(this.el);
         }

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -707,7 +707,7 @@ class TooltipView extends ComponentView {
 
         const formatter = tooltipModel.get('formatter');
         positionExpr = positionExpr || tooltipModel.get('position');
-        let html = defaultHtml;
+        let html: string | HTMLElement[] = defaultHtml;
         const nearPoint = this._getNearestPoint(
             [x, y],
             params,
@@ -718,7 +718,7 @@ class TooltipView extends ComponentView {
             html = formatUtil.formatTpl(formatter, params, true);
         }
         else if (zrUtil.isFunction(formatter)) {
-            const callback = bind(function (cbTicket: string, html: string) {
+            const callback = bind(function (cbTicket: string, html: string | HTMLElement[]) {
                 if (cbTicket === this._ticket) {
                     tooltipContent.setContent(html, markupStyleCreator, tooltipModel, nearPoint.color, positionExpr);
                     this._updatePosition(

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1053,12 +1053,12 @@ interface TooltipFormatterCallback<T> {
      * For sync callback
      * params will be an array on axis trigger.
      */
-    (params: T, asyncTicket: string): string
+    (params: T, asyncTicket: string): string | HTMLElement[]
     /**
      * For async callback.
      * Returned html string will be a placeholder when callback is not invoked.
      */
-    (params: T, asyncTicket: string, callback: (cbTicket: string, html: string) => void): string
+    (params: T, asyncTicket: string, callback: (cbTicket: string, htmlOrDomNodes: string | HTMLElement[]) => void): string | HTMLElement[]
 }
 
 type TooltipBuiltinPosition = 'inside' | 'top' | 'left' | 'right' | 'bottom';

--- a/test/tooltip-domnode.html
+++ b/test/tooltip-domnode.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <div id="main0"></div>
+        <script>
+            require(['echarts'/*, 'map/js/china' */], function (echarts) {
+                var option;
+                var tooltipContent;
+                // $.getJSON('./data/nutrients.json', function (data) {});
+
+                option = {
+                    xAxis: {},
+                    yAxis: {},
+                    series: {
+                        type: 'line',
+                        data: [[11, 22], [33, 44]]
+                    },
+                    tooltip: {
+                        formatter: () => {
+                            if (!tooltipContent) {
+                                tooltipContent = document.createElement('span');
+                                document.body.appendChild(tooltipContent);
+                                var setDate = () => tooltipContent.innerHTML = new Date();
+                                setDate();
+                                setInterval(setDate , 1000);
+                            };
+                            return [tooltipContent];
+                        }
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        'Tooltip formatter returns DOM node',
+                        '(Tooltip show current time)'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
+
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Allows Tooltip to be set with array of DOM Nodes instead of HTML string.


### Fixed issues

- #13250


## Details

### Before: What was the problem?

When the tooltip is set, you could only pass static HTML content. I am developing an Angular app. Angular – like other web frameworks (e.g Vue, React) – has its own template mechanism to generate DOM nodes and retain control over their contents, to update them dynamically. However, I could not leverage my framework inside echarts tooltip.

### After: How is it fixed in this PR?

A non-framework approach is shown in the test file `tooltip-domnode.html`. That tooltip shows the continuously updating current date.
In my Angular project. I can return `this.viewContainerRef.createEmbeddedView(template, context).rootNodes` from the `EChartOption.Tooltip.Formatter` and my tooltip content will be updated in Angular's lifecycle mechanism.


## Usage

### Are there any API changes?

- [x] The API has been changed.

Previously this was the Formatter interface in Typescript:
```typescript
interface Formatter {
    (params: Format | Format[], ticket: string, callback: (ticket: string, html: string) => void): string;
}
```
Now it is this:
```typescript
interface Formatter {
    (params: Format | Format[], ticket: string, callback: (ticket: string, htmlOrDomNodes: string | any[]) => void): string | any[];
}
```

### Related test cases or examples to use the new APIs

- `tooltip-domnode.html`



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
