### PR TITLE
feat(decal): using "none" to disable decal

### DIFF
--- a/src/util/decal.ts
+++ b/src/util/decal.ts
@@ -23,13 +23,17 @@ const decalKeys = [
 /**
  * Create or update pattern image from decal options
  *
- * @param {InnerDecalObject} decalObject decal options
- * @return {Pattern} pattern with generated image
+ * @param {InnerDecalObject | 'none'} decalObject decal options, 'none' if no decal
+ * @return {Pattern} pattern with generated image, null if no decal
  */
 export function createOrUpdatePatternFromDecal(
-    decalObject: InnerDecalObject,
+    decalObject: InnerDecalObject | 'none',
     api: ExtensionAPI
 ): PatternObject {
+    if (decalObject === 'none') {
+        return null;
+    }
+
     const dpr = api.getDevicePixelRatio();
     const zr = api.getZr();
     const isSVG = zr.painter.type === 'svg';

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -871,7 +871,7 @@ export interface SymbolOptionMixin<T = unknown> {
 export interface ItemStyleOption extends ShadowOptionMixin, BorderOptionMixin {
     color?: ZRColor
     opacity?: number
-    decal?: DecalObject[]
+    decal?: DecalObject | 'none'
 }
 
 /**

--- a/test/decal.html
+++ b/test/decal.html
@@ -128,15 +128,25 @@ under the License.
                 if (i === 0) {
                     s.itemStyle = itemStyle;
                 }
+                else if (i === 1) {
+                    s.itemStyle = {
+                        decal: 'none'
+                    };
+                }
+                else if (i === 2) {
+                    s.data = [{
+                        value: s.data[0],
+                        itemStyle: {
+                            decal: 'none'
+                        }
+                    }];
+                }
                 series.push(s);
 
                 var p = {
                     name: 'pie' + i,
                     value: i * 5 + 10
                 };
-                if (i === 0) {
-                    p.itemStyle = itemStyle;
-                }
                 pieData.push(p);
 
                 legendNames.push('bar' + i, 'pie' + i);
@@ -175,7 +185,8 @@ under the License.
                 title: [
                     'It should use decal when aria.show is true',
                     '(1) Each bar and pie piece should have different decal',
-                    '(2) The first bar and pie piece decal should be blue'
+                    '(2) The first bar decal should be blue',
+                    '(3) The second and third bar should not have decal'
                 ],
                 option: option
                 // height: 300,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

This PR makes it possible to disable decal with `itemStyle.decal: 'none'`.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

Previously, there is no way to disable a certain series or data item with decal, if the aria decal is enabled.



### After: How is it fixed in this PR?

This PR makes it possible to disable decal with `itemStyle.decal: 'none'`.



## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

`test/decal.html`.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
