### PR TITLE
fix(line): only bolder when line width in normal state is larger than 0.

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -734,8 +734,7 @@ class LineView extends ChartView {
 
         setStatesStylesFromModel(polyline, seriesModel, 'lineStyle');
 
-        const shouldBolderOnEmphasis = seriesModel.get(['emphasis', 'lineStyle', 'width']) === 'bolder';
-        if (shouldBolderOnEmphasis) {
+        if (polyline.style.lineWidth > 0 && seriesModel.get(['emphasis', 'lineStyle', 'width']) === 'bolder') {
             const emphasisLineStyle = polyline.getState('emphasis').style;
             emphasisLineStyle.lineWidth = polyline.style.lineWidth + 1;
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Don't bolder when the line width in the normal state is 0.


### Fixed issues

N/A.


## Details

If users specify the line width in the normal state as 0, the bolder logic should be skipped.

## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->


### Related test cases or examples to use the new APIs

See `test/line-boldWhenHover.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
