### PR TITLE
fix: [parallel] fix that the second category parallel axis can not be selectable

### DIFF
--- a/src/model/referHelper.ts
+++ b/src/model/referHelper.ts
@@ -32,6 +32,9 @@ import type PolarModel from '../coord/polar/PolarModel';
 import type { SeriesOption, SeriesOnCartesianOptionMixin } from '../util/types';
 import type { AxisBaseModel } from '../coord/AxisBaseModel';
 import { SINGLE_REFERRING } from '../util/model';
+import { ParallelSeriesOption } from '../chart/parallel/ParallelSeries';
+import ParallelModel from '../coord/parallel/ParallelModel';
+import ParallelAxisModel from '../coord/parallel/AxisModel';
 
 /**
  * @class
@@ -183,26 +186,20 @@ const fetchers: Record<SupportedCoordSys, Fetcher> = {
     parallel: function (seriesModel, result, axisMap, categoryAxisMap) {
         const ecModel = seriesModel.ecModel;
         const parallelModel = ecModel.getComponent(
-            // @ts-ignore
-            'parallel', seriesModel.get('parallelIndex')
-        );
-        // @ts-ignore
+            'parallel', (seriesModel as SeriesModel<ParallelSeriesOption>).get('parallelIndex')
+        ) as ParallelModel;
         const coordSysDims = result.coordSysDims = parallelModel.dimensions.slice();
 
-            // @ts-ignore
         each(parallelModel.parallelAxisIndex, function (axisIndex, index) {
-            // @ts-ignore
-            const axisModel = ecModel.getComponent('parallelAxis', axisIndex);
+            const axisModel = ecModel.getComponent('parallelAxis', axisIndex) as ParallelAxisModel;
             const axisDim = coordSysDims[index];
-            // @ts-ignore
             axisMap.set(axisDim, axisModel);
 
-            // @ts-ignore
-            if (isCategory(axisModel) && result.firstCategoryDimIndex == null) {
-                // @ts-ignore
+            if (isCategory(axisModel)) {
                 categoryAxisMap.set(axisDim, axisModel);
-                // @ts-ignore
-                result.firstCategoryDimIndex = index;
+                if (result.firstCategoryDimIndex == null) {
+                    result.firstCategoryDimIndex = index;
+                }
             }
         });
     }

--- a/test/parallel-feature.html
+++ b/test/parallel-feature.html
@@ -38,6 +38,7 @@ under the License.
 
 
         <div id="change-smooth"></div>
+        <div id="two-cateogry-axis-at-last"></div>
 
 
 
@@ -102,8 +103,7 @@ under the License.
 
             var chart = testHelper.create(echarts, 'change-smooth', {
                 title: [
-                    'Test Case Description of main0',
-                    '(Muliple lines and **emphasis** are supported in description)'
+                    'Click btns one by one'
                 ],
                 option: option,
                 width: 600,
@@ -132,6 +132,56 @@ under the License.
             });
         });
         </script>
+
+
+
+
+
+
+
+
+        <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+            var option;
+
+            option = {
+                parallelAxis: [{
+                    dim: 3,
+                    name: 'Score',
+                    type: 'category',
+                    data: ['Excellent', 'Good', 'OK', 'Bad']
+                }, {
+                    dim: 4,
+                    name: 'Score',
+                    type: 'category',
+                    data: ['A', 'B', 'C', 'D']
+                }],
+                series: {
+                    type: 'parallel',
+                    lineStyle: {
+                        width: 4
+                    },
+                    data: [
+                        [12.99, 100, 82, 'Good', 'A'],
+                        [9.99, 80, 77, 'OK', 'A'],
+                        [20, 120, 60, 'Excellent', 'C']
+                    ]
+                }
+            };
+
+
+            var chart = testHelper.create(echarts, 'two-cateogry-axis-at-last', {
+                title: [
+                    'Brush on the last axis. lines should be selectable.'
+                ],
+                option: option,
+                width: 600,
+                height: 300
+            });
+        });
+        </script>
+
+
 
 
     </body>


### PR DESCRIPTION
fix: [parallel] fix that the second category parallel axis can not be selectable

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


