### PR TITLE
feat(decal): symbol support array

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -662,7 +662,7 @@ export type DecalDashArrayX = number | (number | number[])[];
 export type DecalDashArrayY = number | number[];
 export interface DecalObject {
     // 'image', 'triangle', 'diamond', 'pin', 'arrow', 'line', 'rect', 'roundRect', 'square', 'circle'
-    symbol?: string
+    symbol?: string | (string | string[])
 
     // size relative to the dash bounding box; valued from 0 to 1
     symbolSize?: number

--- a/test/decal.html
+++ b/test/decal.html
@@ -210,7 +210,8 @@ under the License.
             var pieData = [];
             var itemStyle = {
                 decal: {
-                    color: 'blue'
+                    color: 'blue',
+                    symbol: [['rect', 'circle', 'triangle'], ['circle', 'none']]
                 }
             };
             for (var i = 0; i < 6; ++i) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Support symbol as array in decal.


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

`symbol` can only be `string`.



### After: How is it fixed in this PR?

`symbol` can be `string | string[] | string[][]` so that different symbol type can be used for different rows and columns.


## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

`test/decal.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
