### PR TITLE
fix: markLine (horizontal or vertical) should be displayed after this optimization.

### DIFF
--- a/src/coord/cartesian/Cartesian2D.ts
+++ b/src/coord/cartesian/Cartesian2D.ts
@@ -107,14 +107,22 @@ class Cartesian2D extends Cartesian<Axis2D> implements CoordinateSystem {
 
     dataToPoint(data: ScaleDataValue[], reserved?: unknown, out?: number[]): number[] {
         out = out || [];
-        if (this._transform && !isNaN(data[0] as number) && !isNaN(data[1] as number)) {
-            // Fast path
+        const xVal = data[0];
+        const yVal = data[1];
+        // Fast path
+        if (this._transform
+            // It's supported that if data is like `[Inifity, 123]`, where only Y pixel calculated.
+            && xVal != null
+            && isFinite(xVal as number)
+            && yVal != null
+            && isFinite(yVal as number)
+        ) {
             return applyTransform(out, data as number[], this._transform);
         }
         const xAxis = this.getAxis('x');
         const yAxis = this.getAxis('y');
-        out[0] = xAxis.toGlobalCoord(xAxis.dataToCoord(data[0]));
-        out[1] = yAxis.toGlobalCoord(yAxis.dataToCoord(data[1]));
+        out[0] = xAxis.toGlobalCoord(xAxis.dataToCoord(xVal));
+        out[1] = yAxis.toGlobalCoord(yAxis.dataToCoord(yVal));
         return out;
     }
 

--- a/test/timeline-layout.html
+++ b/test/timeline-layout.html
@@ -232,17 +232,19 @@ under the License.
                                         symbol : ['arrow','none'],
                                         symbolSize : [4, 2],
                                         itemStyle : {
-                                            normal: {
-                                                lineStyle: {color:'orange'},
-                                                barBorderColor:'orange',
-                                                label:{
-                                                    position:'left',
-                                                    formatter:function(params){
-                                                        return Math.round(params.value);
-                                                    },
-                                                    textStyle:{color:'orange'}
-                                                }
-                                            }
+                                            lineStyle: {color:'orange'},
+                                            barBorderColor:'orange',
+                                        },
+                                        label:{
+                                            // position: 'left' is a invalid value, but exists in this historical file,
+                                            // while will be ignored before v5.0 .
+                                            // But since v5.0, position: 'left' will cause incorrect result.
+                                            // position: 'left',
+                                            position: 'start',
+                                            formatter:function(params){
+                                                return Math.round(params.value);
+                                            },
+                                            textStyle: {color:'orange'}
                                         },
                                         'data':[{'type':'average','name':'平均值'}]
                                     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


Test case:
test/scatter-markline.html


### PENDING
```js
markLine: {
    label: {
        position: 'left'
    }
}
```
is an invalid value, but exists in this historical file (`test/timeline-layout.html`),
while will be ignored before v5.0 .
But since v5.0, position: 'left' will cause incorrect result.
Should we compat it?
