### PR TITLE
Fix/use UTC and tooltip.formatter on time axis

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -31,6 +31,7 @@ import * as axisHelper from '../../coord/axisHelper';
 import * as axisPointerViewHelper from '../axisPointer/viewHelper';
 import { getTooltipRenderMode } from '../../util/model';
 import ComponentView from '../../view/Component';
+import { format as timeFormat } from '../../util/time';
 import {
     HorizontalAlign,
     VerticalAlign,
@@ -716,7 +717,14 @@ class TooltipView extends ComponentView {
         );
 
         if (formatter && zrUtil.isString(formatter)) {
-            html = formatUtil.formatTpl(formatter, params, true);
+            const useUTC = tooltipModel.ecModel.get('useUTC');
+            const params0 = zrUtil.isArray(params) ? params[0] : params;
+            const isTimeAxis = params0 && params0.axisType && params0.axisType.indexOf('time') >= 0;
+            html = formatter;
+            if (isTimeAxis) {
+                html = timeFormat(params0.axisValue, html, useUTC);
+            }
+            html = formatUtil.formatTpl(html, params, true);
         }
         else if (zrUtil.isFunction(formatter)) {
             const callback = bind(function (cbTicket: string, html: string | HTMLElement[]) {

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -541,7 +541,7 @@ class TooltipView extends ComponentView {
         const orderMode = singleTooltipModel.get('order');
 
         const builtMarkupText = buildTooltipMarkup(
-            articleMarkup, markupStyleCreator, renderMode, orderMode
+            articleMarkup, markupStyleCreator, renderMode, orderMode, ecModel.get('useUTC')
         );
         builtMarkupText && markupTextArrLegacy.unshift(builtMarkupText);
         const blockBreak = renderMode === 'richText' ? '\n\n' : '<br/>';
@@ -619,7 +619,8 @@ class TooltipView extends ComponentView {
                 seriesTooltipResult.markupFragment,
                 markupStyleCreator,
                 renderMode,
-                orderMode
+                orderMode,
+                ecModel.get('useUTC')
             )
             : seriesTooltipResult.markupText;
 

--- a/src/component/tooltip/tooltipMarkup.ts
+++ b/src/component/tooltip/tooltipMarkup.ts
@@ -212,7 +212,7 @@ const builderMap: { [key in TooltipMarkupBlockFragment['type']]: TooltipMarkupFr
                 return subMarkupText;
             }
 
-            const displayableHeader = makeValueReadable(fragment.header, 'ordinal');
+            const displayableHeader = makeValueReadable(fragment.header, 'ordinal', ctx.useUTC);
             if (ctx.renderMode === 'richText') {
                 return wrapInlineNameRichText(ctx, displayableHeader) + gaps.richText
                     + subMarkupText;
@@ -247,6 +247,7 @@ const builderMap: { [key in TooltipMarkupBlockFragment['type']]: TooltipMarkupFr
             const noMarker = !fragment.markerType;
             const name = fragment.name;
             const value = fragment.value;
+            const useUTC = ctx.useUTC;
 
             if (noName && noValue) {
                 return;
@@ -261,16 +262,16 @@ const builderMap: { [key in TooltipMarkupBlockFragment['type']]: TooltipMarkupFr
                 );
             const readableName = noName
                 ? ''
-                : makeValueReadable(name, 'ordinal');
+                : makeValueReadable(name, 'ordinal', useUTC);
             const valueTypeOption = fragment.valueType;
             const readableValueList = noValue
                 ? []
                 : (isArray(value)
                     ? map(value, (val, idx) => makeValueReadable(
-                        val, isArray(valueTypeOption) ? valueTypeOption[idx] : valueTypeOption
+                        val, isArray(valueTypeOption) ? valueTypeOption[idx] : valueTypeOption, useUTC
                     ))
                     : [makeValueReadable(
-                        value, isArray(valueTypeOption) ? valueTypeOption[0] : valueTypeOption
+                        value, isArray(valueTypeOption) ? valueTypeOption[0] : valueTypeOption, useUTC
                     )]
                 );
             const valueAlignRight = !noMarker || !noName;
@@ -346,6 +347,7 @@ function buildSubBlocks(
 }
 
 interface TooltipMarkupBuildContext {
+    useUTC: boolean;
     renderMode: TooltipRenderMode;
     orderMode: TooltipOrderMode;
     markupStyleCreator: TooltipMarkupStyleCreator;
@@ -358,7 +360,8 @@ export function buildTooltipMarkup(
     fragment: TooltipMarkupBlockFragment,
     markupStyleCreator: TooltipMarkupStyleCreator,
     renderMode: TooltipRenderMode,
-    orderMode: TooltipOrderMode
+    orderMode: TooltipOrderMode,
+    useUTC: boolean
 ): MarkupText {
     if (!fragment) {
         return;
@@ -367,6 +370,7 @@ export function buildTooltipMarkup(
     const builder = getBuilder(fragment);
     builder.planLayout(fragment);
     const ctx: TooltipMarkupBuildContext = {
+        useUTC: useUTC,
         renderMode: renderMode,
         orderMode: orderMode,
         markupStyleCreator: markupStyleCreator

--- a/src/scale/Time.ts
+++ b/src/scale/Time.ts
@@ -127,8 +127,8 @@ class TimeScale extends IntervalScale<TimeScaleSetting> {
             fullLeveledFormatter[
                 getDefaultFormatPrecisionOfInterval(getPrimaryTimeUnit(this._minLevelUnit))
             ] || fullLeveledFormatter.second,
-            this.getSetting('locale'),
-            useUTC
+            useUTC,
+            this.getSetting('locale')
         );
     }
 
@@ -337,7 +337,7 @@ function isUnitValueSame(
 //     millisecond: millisecondsGetterName(true)
 // };
 
-// function moveTick(date: Date, unitName: TimeUnit, step: number, isUTC?: boolean) {
+// function moveTick(date: Date, unitName: TimeUnit, step: number, isUTC: boolean) {
 //     step = step || 1;
 //     switch (getPrimaryTimeUnit(unitName)) {
 //         case 'year':

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -79,7 +79,8 @@ export function encodeHTML(source: string): string {
  */
 export function makeValueReadable(
     value: unknown,
-    valueType: DimensionType
+    valueType: DimensionType,
+    useUTC: boolean
 ): string {
     const USER_READABLE_DEFUALT_TIME_PATTERN = 'yyyy-MM-dd hh:mm:ss';
 
@@ -95,7 +96,7 @@ export function makeValueReadable(
     if (isTypeTime || isValueDate) {
         const date = isTypeTime ? parseDate(value) : value;
         if (!isNaN(+date)) {
-            return timeFormat(date, USER_READABLE_DEFUALT_TIME_PATTERN);
+            return timeFormat(date, USER_READABLE_DEFUALT_TIME_PATTERN, useUTC);
         }
         else if (isValueDate) {
             return '-';
@@ -273,7 +274,7 @@ export function getTooltipMarker(inOpt: ColorString | GetTooltipMarkerOpt, extra
  *           and `module:echarts/util/number#parseDate`.
  * @inner
  */
-export function formatTime(tpl: string, value: unknown, isUTC?: boolean) {
+export function formatTime(tpl: string, value: unknown, isUTC: boolean) {
     if (__DEV__) {
         deprecateReplaceLog('echarts.format.formatTime', 'echarts.time.format');
     }

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -148,20 +148,6 @@ export function formatTpl(
         return '';
     }
 
-    // TODO:
-    // This commented code is to support `tooltip.formatter: '{yyyy}-{mm}-{dd}'`, but not correct.
-    // It should ensure:
-    // (1) `useUTC` is not forgotten to be set as `true` or `false`.
-    //     The result based on useUTC are totally different, which should not be omitted.
-    // (2) Should not break the original funtion: tooltip.formatter: '{a0} {a1}'
-    // (3) Consider `series.encode: {x: 2}`, that is, `param.data[2]` is time axis value.
-    // const isTimeAxis = paramsList[0].axisType && paramsList[0].axisType.indexOf('time') >= 0;
-    // if (isTimeAxis) {
-    //     const axisValue = paramsList[0].data[paramsList[0].axisIndex];
-    //     const date = parseDate(axisValue);
-    //     return timeFormat(date, tpl);
-    // }
-
     const $vars = paramsList[0].$vars || [];
     for (let i = 0; i < $vars.length; i++) {
         const alias = TPL_VAR_ALIAS[i];

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -106,7 +106,9 @@ export function getDefaultFormatPrecisionOfInterval(timeUnit: PrimaryTimeUnit): 
 }
 
 export function format(
-    time: unknown, template: string, lang?: string | Model<LocaleOption>, isUTC?: boolean
+    // Note: The result based on `isUTC` are totally different, which can not be just simply
+    // substituted by the result without `isUTC`. So we make the param `isUTC` mandatory.
+    time: unknown, template: string, isUTC: boolean, lang?: string | Model<LocaleOption>
 ): string {
     const date = numberUtil.parseDate(time);
     const y = date[fullYearGetterName(isUTC)]();
@@ -159,7 +161,7 @@ export function leveledFormat(
     idx: number,
     formatter: TimeAxisLabelFormatterOption,
     lang: string | Model<LocaleOption>,
-    isUTC?: boolean
+    isUTC: boolean
 ) {
     let template = null;
     if (typeof formatter === 'string') {
@@ -212,7 +214,7 @@ export function leveledFormat(
         }
     }
 
-    return format(new Date(tick.value), template, lang, isUTC);
+    return format(new Date(tick.value), template, isUTC, lang);
 }
 
 export function getUnitFromValue(
@@ -259,8 +261,8 @@ export function getUnitFromValue(
 
 export function getUnitValue(
     value: number | Date,
-    unit?: TimeUnit,
-    isUTC?: boolean
+    unit: TimeUnit,
+    isUTC: boolean
 ) : number {
     const date = typeof value === 'number'
         ? numberUtil.parseDate(value)
@@ -291,58 +293,58 @@ export function getUnitValue(
     }
 }
 
-export function fullYearGetterName(isUTC?: boolean) {
+export function fullYearGetterName(isUTC: boolean) {
     return isUTC ? 'getUTCFullYear' : 'getFullYear';
 }
 
-export function monthGetterName(isUTC?: boolean) {
+export function monthGetterName(isUTC: boolean) {
     return isUTC ? 'getUTCMonth' : 'getMonth';
 }
 
-export function dateGetterName(isUTC?: boolean) {
+export function dateGetterName(isUTC: boolean) {
     return isUTC ? 'getUTCDate' : 'getDate';
 }
 
-export function hoursGetterName(isUTC?: boolean) {
+export function hoursGetterName(isUTC: boolean) {
     return isUTC ? 'getUTCHours' : 'getHours';
 }
 
-export function minutesGetterName(isUTC?: boolean) {
+export function minutesGetterName(isUTC: boolean) {
     return isUTC ? 'getUTCMinutes' : 'getMinutes';
 }
 
-export function secondsGetterName(isUTC?: boolean) {
+export function secondsGetterName(isUTC: boolean) {
     return isUTC ? 'getUTCSeconds' : 'getSeconds';
 }
 
-export function millisecondsGetterName(isUTC?: boolean) {
+export function millisecondsGetterName(isUTC: boolean) {
     return isUTC ? 'getUTCSeconds' : 'getSeconds';
 }
 
-export function fullYearSetterName(isUTC?: boolean) {
+export function fullYearSetterName(isUTC: boolean) {
     return isUTC ? 'setUTCFullYear' : 'setFullYear';
 }
 
-export function monthSetterName(isUTC?: boolean) {
+export function monthSetterName(isUTC: boolean) {
     return isUTC ? 'setUTCMonth' : 'setMonth';
 }
 
-export function dateSetterName(isUTC?: boolean) {
+export function dateSetterName(isUTC: boolean) {
     return isUTC ? 'setUTCDate' : 'setDate';
 }
 
-export function hoursSetterName(isUTC?: boolean) {
+export function hoursSetterName(isUTC: boolean) {
     return isUTC ? 'setUTCHours' : 'setHours';
 }
 
-export function minutesSetterName(isUTC?: boolean) {
+export function minutesSetterName(isUTC: boolean) {
     return isUTC ? 'setUTCMinutes' : 'setMinutes';
 }
 
-export function secondsSetterName(isUTC?: boolean) {
+export function secondsSetterName(isUTC: boolean) {
     return isUTC ? 'setUTCSeconds' : 'setSeconds';
 }
 
-export function millisecondsSetterName(isUTC?: boolean) {
+export function millisecondsSetterName(isUTC: boolean) {
     return isUTC ? 'setUTCSeconds' : 'setSeconds';
 }

--- a/test/timeZone.html
+++ b/test/timeZone.html
@@ -91,7 +91,7 @@ under the License.
                     tooltip: {
                         trigger: 'axis',
                         // test in Safari (NaN-NaN-NaN NaN:NaN:NaN)
-                        formatter: '{yyyy}-{MM}-{dd} {HH}:{mm}:{ss}'
+                        // formatter: '{yyyy}-{MM}-{dd} {HH}:{mm}:{ss}'
                     },
                     xAxis: [{
                         type: 'time',
@@ -121,15 +121,13 @@ under the License.
                         smooth: true,
                         data: data,
                         label: {
-                            normal: {
-                                show: true,
-                                formatter: function (params) {
-                                    return echarts.time.format(
-                                        params.value[0],
-                                        '{yyyy}-{MM}-{dd} {HH}:{mm}:{ss}',
-                                        useUTC
-                                    );
-                                }
+                            show: true,
+                            formatter: function (params) {
+                                return echarts.time.format(
+                                    params.value[0],
+                                    '{yyyy}-{MM}-{dd} {HH}:{mm}:{ss}',
+                                    useUTC
+                                );
                             }
                         }
                     }]

--- a/test/timeZone.html
+++ b/test/timeZone.html
@@ -29,12 +29,11 @@ under the License.
     <body>
         <style>
             h1 {
-                line-height: 60px;
-                height: 60px;
                 background: #ddd;
                 text-align: center;
                 font-weight: bold;
                 font-size: 14px;
+                padding: 20px 0;
             }
             .chart {
                 height: 350px;
@@ -45,8 +44,17 @@ under the License.
         <h1>time scale label should in local time when timestamp (in UTC) input, tick should align with day.</h1>
         <div class="chart" id="chart0"></div>
 
-        <h1>time scale label should in UTC time when option.useUTC is `true`, tick should not align with day.</h1>
+        <h1>
+            time scale label should in UTC time when option.useUTC is `true`, tick should not align with day.<br>
+            tooltip (default) should be OK.
+        </h1>
         <div class="chart" id="chart1"></div>
+
+        <h1>
+            time scale label should in UTC time when option.useUTC is `true`, tick should not align with day.<br>
+            tooltip (formatter: series0 2017-02-09 16:00) should be OK.
+        </h1>
+        <div class="chart" id="chart1-1"></div>
 
         <h1>useUTC: null, should display '00:00 01-03' in tooltip on the 1st point</h1>
         <div class="chart" id="chart2"></div>
@@ -85,13 +93,17 @@ under the License.
                 ['2012-01-06', 290000]
             ];
 
-            function makeTimeScaleOption(data, useUTC) {
+            // opt: {useUTC, tooltipFormatter}
+            function makeTimeScaleOption(data, opt) {
+                opt = opt || {};
+                var useUTC = opt.useUTC;
+                var tooltipFormatter = opt.tooltipFormatter;
                 return {
                     useUTC: useUTC,
                     tooltip: {
                         trigger: 'axis',
                         // test in Safari (NaN-NaN-NaN NaN:NaN:NaN)
-                        // formatter: '{yyyy}-{MM}-{dd} {HH}:{mm}:{ss}'
+                        formatter: tooltipFormatter
                     },
                     xAxis: [{
                         type: 'time',
@@ -152,14 +164,6 @@ under the License.
 
             require([
                 'echarts'
-                // 'zrender/tool/color',
-                // 'echarts/chart/line',
-                // 'echarts/component/grid',
-                // 'echarts/component/legend',
-                // 'echarts/component/tooltip',
-                // 'echarts/component/toolbox',
-                // 'echarts/component/visualMap',
-                // 'echarts/component/dataZoom'
             ], function (ec) {
                 echarts = ec;
                 colorTool = echarts.color;
@@ -194,14 +198,6 @@ under the License.
 
             require([
                 'echarts'
-                // 'zrender/tool/color',
-                // 'echarts/chart/line',
-                // 'echarts/component/grid',
-                // 'echarts/component/legend',
-                // 'echarts/component/tooltip',
-                // 'echarts/component/toolbox',
-                // 'echarts/component/visualMap',
-                // 'echarts/component/dataZoom'
             ], function (ec) {
                 echarts = ec;
                 colorTool = echarts.color;
@@ -211,7 +207,7 @@ under the License.
                 }
                 chart = myChart = echarts.init(dom);
 
-                var option = makeTimeScaleOption(dataTimestamp, true);
+                var option = makeTimeScaleOption(dataTimestamp, {useUTC: true});
 
                 chart.setOption(option);
             });
@@ -223,6 +219,38 @@ under the License.
 
 
 
+
+
+
+        <script>
+
+            var echarts;
+            var colorTool;
+            var chart;
+            var myChart;
+            var groupCategories = [];
+            var groupColors = [];
+
+            require([
+                'echarts'
+            ], function (ec) {
+                echarts = ec;
+                colorTool = echarts.color;
+                var dom = document.getElementById('chart1-1');
+                if (!dom) {
+                    return;
+                }
+                chart = myChart = echarts.init(dom);
+
+                var option = makeTimeScaleOption(
+                    dataTimestamp,
+                    {useUTC: true, tooltipFormatter: '{a0} {yyyy}-{MM}-{dd} {HH}:{mm}:{ss}'}
+                );
+
+                chart.setOption(option);
+            });
+
+        </script>
 
 
 
@@ -245,14 +273,6 @@ under the License.
 
             require([
                 'echarts'
-                // 'zrender/tool/color',
-                // 'echarts/chart/line',
-                // 'echarts/component/grid',
-                // 'echarts/component/legend',
-                // 'echarts/component/tooltip',
-                // 'echarts/component/toolbox',
-                // 'echarts/component/visualMap',
-                // 'echarts/component/dataZoom'
             ], function (ec) {
                 echarts = ec;
                 colorTool = echarts.color;
@@ -290,14 +310,6 @@ under the License.
 
             require([
                 'echarts'
-                // 'zrender/tool/color',
-                // 'echarts/chart/line',
-                // 'echarts/component/grid',
-                // 'echarts/component/legend',
-                // 'echarts/component/tooltip',
-                // 'echarts/component/toolbox',
-                // 'echarts/component/visualMap',
-                // 'echarts/component/dataZoom'
             ], function (ec) {
                 echarts = ec;
                 colorTool = echarts.color;
@@ -307,7 +319,7 @@ under the License.
                 }
                 chart = myChart = echarts.init(dom);
 
-                var option = makeTimeScaleOption(dataTimeString, true);
+                var option = makeTimeScaleOption(dataTimeString, {useUTC: true});
 
                 chart.setOption(option);
             });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


<br>
<br>

+ tooltip should support useUTC by default.
+ Make the param useUTC/isUTC mandatory rather than optional, which enables to check where useUTC is omitted. Theoretically, the result without useUTC can not substitute the result with useUTC.
+ Change the order of the param isUTC and lang of time.format because isUTC is used more.
+ Comment incorrect implementation of `tooltip.formatter: pattern` on time axis temporarily. Because it should ensure:
    + `useUTC` is not forgotten to be set as `true` or `false`. The result based on useUTC are totally different, which should not be omitted.
    + Should not break the original funtion: tooltip.formatter: '{a0} {a1}'
    + Consider `series.encode: {x: 2}`, that is, `param.data[2]` is time axis value.


Test case: test/timeZome.html
