### PR TITLE
fix: fix timeline tick symbol displayed at wrong place.

### DIFF
--- a/src/component/timeline/SliderTimelineView.ts
+++ b/src/component/timeline/SliderTimelineView.ts
@@ -430,7 +430,8 @@ class SliderTimelineView extends TimelineView {
             const progressStyleModel = itemModel.getModel(['progress', 'itemStyle']);
 
             const symbolOpt = {
-                position: [tickCoord, 0],
+                x: tickCoord,
+                y: 0,
                 onclick: bind(this._changeTimeline, this, tick.value)
             };
             const el = giveSymbol(itemModel, itemStyleModel, group, symbolOpt);

--- a/test/timeline-layout.html
+++ b/test/timeline-layout.html
@@ -73,7 +73,7 @@ under the License.
                     timeline: {
                         inverse: true,
                         symbol: 'path://M0,0L10,0L10,10L0,10L0,0z',
-                        symbolSize: [1, 6],
+                        symbolSize: [10, 6],
                         symbolOffset: [0, 3],
                         symbolRotate: 30
                     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

test case: test/timeline-layout.html (the 2nd case)