### PR TITLE
chore: add tslib in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "lint:dist": "echo 'It might take a while. Please wait ...' && ./node_modules/.bin/jshint --config .jshintrc-dist dist/echarts.js"
   },
   "dependencies": {
-    "zrender": "5.0.0-beta.2"
+    "zrender": "5.0.0-beta.2",
+    "tslib": "1.10.0"
   },
   "devDependencies": {
     "@babel/core": "7.3.4",


### PR DESCRIPTION
For some reason. tslib may be installed in the `zrender/node_modules` when installing dependencies. Which may lead to echarts can't find tslib. So we add the same tslib dependencies in echarts.