### PR TITLE
fix: [dataZoom] fix that after dataZoom updated by others (like inside dataZoom), the brush rect does not display.

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -191,6 +191,7 @@ class SliderZoomView extends DataZoomView {
         thisGroup.removeAll();
 
         this._brushing = false;
+        this._displayables.brushRect = null;
 
         this._resetLocation();
         this._resetInterval();
@@ -988,7 +989,8 @@ class SliderZoomView extends DataZoomView {
             });
             displayables.sliderGroup.add(brushRect);
         }
-        brushRect.ignore = false;
+
+        brushRect.attr('ignore', false);
 
         const brushStart = this._brushStart;
 


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


