### PR TITLE
Fix(tree): `symbol` is `none` cannot be skipped

### DIFF
--- a/src/chart/tree/TreeView.ts
+++ b/src/chart/tree/TreeView.ts
@@ -362,8 +362,7 @@ function symbolNeedsDraw(data: List, dataIndex: number) {
     const layout = data.getItemLayout(dataIndex);
 
     return layout
-        && !isNaN(layout.x) && !isNaN(layout.y)
-        && data.getItemVisual(dataIndex, 'symbol') !== 'none';
+        && !isNaN(layout.x) && !isNaN(layout.y);
 }
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
Close #13560


## Details

### Before: What was the problem?
`tree` didn't drawn when `symbol`  was `none`



### After: How is it fixed in this PR?
<img width="598" alt="Screen Shot 2020-11-09 at 23 59 26" src="https://user-images.githubusercontent.com/20318608/98564773-c0a8a680-22e7-11eb-923a-b77705d0bf44.png">



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
