### PR TITLE
fix(axis): when category axis max is greater than data length

### DIFF
--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -486,7 +486,7 @@ class BarView extends ChartView {
 
         let lastValue = Number.MAX_VALUE;
         for (let i = 0; i < oldOrder.length; ++i) {
-            const value = orderMap(oldOrder[i].ordinalNumber);
+            const value = orderMap(oldOrder[i] && oldOrder[i].ordinalNumber);
             if (value > lastValue) {
                 return true;
             }

--- a/src/scale/Ordinal.ts
+++ b/src/scale/Ordinal.ts
@@ -67,7 +67,6 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
             });
         }
         this._ordinalMeta = ordinalMeta as OrdinalMeta;
-        this._categorySortInfo = null;
         this._extent = this.getSetting('extent') || [0, ordinalMeta.categories.length - 1];
     }
 
@@ -134,7 +133,9 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
         const categorySortInfo = this._categorySortInfo;
         if (categorySortInfo) {
             // Sorted
-            return categorySortInfo[n] && categorySortInfo[n].beforeSortIndex;
+            return categorySortInfo[n]
+                ? categorySortInfo[n].beforeSortIndex
+                : -1;
         }
         else {
             // Not sorted

--- a/src/scale/Ordinal.ts
+++ b/src/scale/Ordinal.ts
@@ -67,7 +67,7 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
             });
         }
         this._ordinalMeta = ordinalMeta as OrdinalMeta;
-        this._categorySortInfo = [];
+        this._categorySortInfo = null;
         this._extent = this.getSetting('extent') || [0, ordinalMeta.categories.length - 1];
     }
 
@@ -131,10 +131,13 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
      * @param {OrdinalNumber} n index of raw data
      */
     getCategoryIndex(n: OrdinalNumber): OrdinalNumber {
-        if (this._categorySortInfo.length) {
-            return this._categorySortInfo[n].beforeSortIndex;
+        const categorySortInfo = this._categorySortInfo;
+        if (categorySortInfo) {
+            // Sorted
+            return categorySortInfo[n] && categorySortInfo[n].beforeSortIndex;
         }
         else {
+            // Not sorted
             return n;
         }
     }
@@ -145,15 +148,14 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
      * @param {OrdinalNumber} displayIndex index of display
      */
     getRawIndex(displayIndex: OrdinalNumber): OrdinalNumber {
-        if (this._categorySortInfo.length) {
+        const categorySortInfo = this._categorySortInfo;
+        if (categorySortInfo) {
             // Sorted
-            if (this._categorySortInfo[displayIndex] == null) {
+            return categorySortInfo[displayIndex]
+                // In range, return ordinalNumber
+                ? categorySortInfo[displayIndex].ordinalNumber
                 // Out of range, e.g., when axis max is larger than cagetory number
-                return null;
-            }
-            else {
-                return this._categorySortInfo[displayIndex].ordinalNumber;
-            }
+                : -1;
         }
         else {
             // Not sorted
@@ -167,15 +169,10 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
     getLabel(tick: ScaleTick): string {
         if (!this.isBlank()) {
             const rawIndex = this.getRawIndex(tick.value);
-            if (rawIndex == null) {
-                return '';
-            }
-            else {
-                const cateogry = this._ordinalMeta.categories[rawIndex];
-                // Note that if no data, ordinalMeta.categories is an empty array.
-                // Return empty if it's not exist.
-                return cateogry == null ? '' : cateogry + '';
-            }
+            const cateogry = this._ordinalMeta.categories[rawIndex];
+            // Note that if no data, ordinalMeta.categories is an empty array.
+            // Return empty if it's not exist.
+            return cateogry == null ? '' : cateogry + '';
         }
     }
 

--- a/src/scale/Ordinal.ts
+++ b/src/scale/Ordinal.ts
@@ -146,9 +146,17 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
      */
     getRawIndex(displayIndex: OrdinalNumber): OrdinalNumber {
         if (this._categorySortInfo.length) {
-            return this._categorySortInfo[displayIndex].ordinalNumber;
+            // Sorted
+            if (this._categorySortInfo[displayIndex] == null) {
+                // Out of range, e.g., when axis max is larger than cagetory number
+                return null;
+            }
+            else {
+                return this._categorySortInfo[displayIndex].ordinalNumber;
+            }
         }
         else {
+            // Not sorted
             return displayIndex;
         }
     }
@@ -159,10 +167,15 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
     getLabel(tick: ScaleTick): string {
         if (!this.isBlank()) {
             const rawIndex = this.getRawIndex(tick.value);
-            const cateogry = this._ordinalMeta.categories[rawIndex];
-            // Note that if no data, ordinalMeta.categories is an empty array.
-            // Return empty if it's not exist.
-            return cateogry == null ? '' : cateogry + '';
+            if (rawIndex == null) {
+                return '';
+            }
+            else {
+                const cateogry = this._ordinalMeta.categories[rawIndex];
+                // Note that if no data, ordinalMeta.categories is an empty array.
+                // Return empty if it's not exist.
+                return cateogry == null ? '' : cateogry + '';
+            }
         }
     }
 

--- a/test/bar-race.html
+++ b/test/bar-race.html
@@ -54,6 +54,9 @@ under the License.
         <div id="main2" class="chart"></div>
 
 
+        <div id="main3" class="chart"></div>
+
+
         <script>
 
         require(
@@ -303,6 +306,60 @@ under the License.
                         };
                     })(x);
                 }
+            }
+
+        );
+        </script>
+
+
+
+        <script>
+
+        require(
+            (testHelper.hasURLParam('en')
+                ? [
+                    'echarts',
+                    // 'echarts/lang/en',
+                ]
+                : [
+                    'echarts'
+                ]
+            ).concat(
+                [
+                    // 'echarts/chart/bar',
+                    // 'echarts/chart/line',
+                    // 'echarts/component/legend',
+                    // 'echarts/component/graphic',
+                    // 'echarts/component/grid',
+                    // 'echarts/component/tooltip',
+                    // 'echarts/component/brush',
+                    // 'echarts/component/toolbox',
+                    // 'echarts/component/title',
+                    // 'zrender/vml/vml'
+                ]
+            ),
+            function (echarts) {
+                var chart = echarts.init(document.getElementById('main3'), null, {
+                });
+                var option = {
+                    title: {
+                        text: 'When yAxis max is larger than yAxis data length, it should not get error'
+                    },
+                    xAxis: {
+                    },
+                    yAxis: {
+                        type: 'category',
+                        data: ['A', 'B', 'C'],
+                        max: 5
+                    },
+                    series: [{
+                        realtimeSort: true,
+                        type: 'bar',
+                        data: [10, 8, 2]
+                    }]
+                };
+
+                chart.setOption(option);
             }
 
         );


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

When a sorted category axis `max` is greater than data length (which sometimes happens for bar race charts), the axis label has error so the chart cannot be rendered.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

With the third test case of `test/bar-race.html`, it gets error and cannot render the chart.

![image](https://user-images.githubusercontent.com/779050/100838930-54682f80-34ae-11eb-930e-962d590fca46.png)


### After: How is it fixed in this PR?

No error.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

`test/bar-race.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
