### PR TITLE
fix(bar-race): fix default categorySortInfo value bug

### DIFF
--- a/src/coord/cartesian/AxisModel.ts
+++ b/src/coord/cartesian/AxisModel.ts
@@ -60,8 +60,7 @@ zrUtil.mixin(CartesianAxisModel, AxisModelCommonMixin);
 const extraOption: CartesianAxisOption = {
     // gridIndex: 0,
     // gridId: '',
-    offset: 0,
-    categorySortInfo: []
+    offset: 0
 };
 
 axisModelCreator<CartesianAxisOption, typeof CartesianAxisModel>('x', CartesianAxisModel, extraOption);


### PR DESCRIPTION
Some cases of line charts and bar charts display no chart.
This is because `categorySortInfo` default value was changed from `[]` to undefined in 84ead77
but `extraOption` did not change accordingly.

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

To fix the bar/line charts problem with `categorySortInfo` default value.

### Fixed issues

<!--
- #xxxx: ...
-->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
