### PR TITLE
fix(endLabel): emphasis values

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -492,7 +492,7 @@ function getEndLabelStateSpecified(endLabelModel: Model, coordSys: Cartesian2D) 
     const isHorizontal = baseAxis.isHorizontal();
     const isBaseInversed = baseAxis.inverse;
     const align = isHorizontal
-        ? isBaseInversed ? 'right' : 'left'
+        ? (isBaseInversed ? 'right' : 'left')
         : 'center';
     const verticalAlign = isHorizontal
         ? 'middle'
@@ -502,7 +502,7 @@ function getEndLabelStateSpecified(endLabelModel: Model, coordSys: Cartesian2D) 
         normal: {
             align: endLabelModel.get('align') || align,
             verticalAlign: endLabelModel.get('verticalAlign') || verticalAlign,
-            padding: endLabelModel.get('distance') || 0
+            padding: endLabelModel.get('padding') || 0
         }
     };
 }
@@ -1059,7 +1059,7 @@ class LineView extends ChartView {
             const dataIndex = getLastIndexNotNull(data.getLayout('points'));
             if (dataIndex >= 0) {
                 setLabelStyle(
-                    endLabel,
+                    polyline,
                     getLabelStatesModels(seriesModel, 'endLabel'),
                     {
                         labelFetcher: seriesModel,
@@ -1072,6 +1072,7 @@ class LineView extends ChartView {
                     },
                     getEndLabelStateSpecified(endLabelModel, coordSys)
                 );
+                polyline.textConfig.position = null;
             }
         }
         else if (this._endLabel) {
@@ -1104,6 +1105,7 @@ class LineView extends ChartView {
             const seriesModel = data.hostModel as LineSeriesModel;
             const connectNulls = seriesModel.get('connectNulls');
             const precision = endLabelModel.get('precision');
+            const distance = endLabelModel.get('distance') || 0;
 
             const baseAxis = coordSys.getBaseAxis();
             const isHorizontal = baseAxis.isHorizontal();
@@ -1113,6 +1115,8 @@ class LineView extends ChartView {
             const xOrY = isBaseInversed
                 ? isHorizontal ? clipShape.x : (clipShape.y + clipShape.height)
                 : isHorizontal ? (clipShape.x + clipShape.width) : clipShape.y;
+            const distanceX = (isHorizontal ? distance : 0) * (isBaseInversed ? -1 : 1);
+            const distanceY = (isHorizontal ? 0 : -distance) * (isBaseInversed ? -1 : 1);
             const dim = isHorizontal ? 'x' : 'y';
 
             const dataIndexRange = getIndexRange(points, xOrY, dim);
@@ -1124,12 +1128,18 @@ class LineView extends ChartView {
                 // diff > 1 && connectNulls, which is on the null data.
                 if (diff > 1 && !connectNulls) {
                     const pt = getPointAtIndex(points, indices[0]);
-                    endLabel.attr({ x: pt[0], y: pt[1] });
+                    endLabel.attr({
+                        x: pt[0] + distanceX,
+                        y: pt[1] + distanceY
+                    });
                     valueAnimation && (value = seriesModel.getRawValue(indices[0]) as ParsedValue);
                 }
                 else {
                     const pt = polyline.getPointOn(xOrY, dim);
-                    pt && endLabel.attr({ x: pt[0], y: pt[1] });
+                    pt && endLabel.attr({
+                        x: pt[0] + distanceX,
+                        y: pt[1] + distanceY
+                    });
 
                     const startValue = seriesModel.getRawValue(indices[0]) as ParsedValue;
                     const endValue = seriesModel.getRawValue(indices[1]) as ParsedValue;
@@ -1145,7 +1155,10 @@ class LineView extends ChartView {
                 const idx = (percent === 1 || animationRecord.lastFrameIndex > 0) ? indices[0] : 0;
                 const pt = getPointAtIndex(points, idx);
                 valueAnimation && (value = seriesModel.getRawValue(idx) as ParsedValue);
-                endLabel.attr({ x: pt[0], y: pt[1] });
+                endLabel.attr({
+                    x: pt[0] + distanceX,
+                    y: pt[1] + distanceY
+                });
             }
             if (valueAnimation) {
                 labelInner(endLabel).setLabelText(value);

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -501,8 +501,7 @@ function getEndLabelStateSpecified(endLabelModel: Model, coordSys: Cartesian2D) 
     return {
         normal: {
             align: endLabelModel.get('align') || align,
-            verticalAlign: endLabelModel.get('verticalAlign') || verticalAlign,
-            padding: endLabelModel.get('padding') || 0
+            verticalAlign: endLabelModel.get('verticalAlign') || verticalAlign
         }
     };
 }

--- a/test/line-endLabel.html
+++ b/test/line-endLabel.html
@@ -36,6 +36,11 @@ under the License.
                 height: 1000px;
                 margin-bottom: 30px;
             }
+            #main2 {
+                width: 100%;
+                height: 300px;
+                margin-bottom: 30px;
+            }
             #formatterSwitchButtons {
                 margin: 10px;
                 padding: 10px;
@@ -122,11 +127,11 @@ under the License.
 
         <div id="main0"></div>
         <div id="main1"></div>
+        <div id="main2"></div>
         <script>
 
             require([
                 'echarts',
-                'theme/infographic'
                 // 'echarts/chart/line',
                 // 'echarts/component/title',
                 // 'echarts/component/legend',
@@ -284,7 +289,8 @@ under the License.
                                         endLabel: {
                                             show: true,
                                             formatter: _endLabelFormatter,
-                                            fontSize: 14
+                                            fontSize: 20,
+                                            distance: 10
                                         },
                                         emphasis: {
                                             endLabel: {
@@ -316,6 +322,75 @@ under the License.
                     })(cid);
 
                 }
+
+            })
+
+        </script>
+
+
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                var xData = [];
+                var data = [];
+                var value = 200;
+                var positive = 1;
+                for (var i = 0; i < 12; ++i) {
+                    xData.push(i + '');
+                    var plus = i === 6 || i === 7
+                        ? 0
+                        : positive * Math.round(Math.random() * 1000);
+                    value = plus + value;
+                    data.push(i === 3 ? '-' : value);
+
+                    if (Math.random() > 0.7) {
+                        positive = -1 * positive;
+                    }
+                }
+
+                var chart = echarts.init(document.getElementById('main2'));
+                var option = {
+                    title: [{
+                        text: 'distance 50, offset [0, 20], rotate 5\nonhover: distance -50, offset [0, -20], rotate -5',
+                        textAlign: 'center',
+                        left: '50%',
+                        top: 0
+                    }],
+                    xAxis: [{
+                        data: xData
+                    }],
+                    yAxis: [{
+                    }],
+                    series: [{
+                        type: 'line',
+                        data: data,
+                        label: {
+                            show: true
+                        },
+                        endLabel: {
+                            show: true,
+                            formatter: _endLabelFormatter,
+                            fontSize: 14,
+                            distance: 50,
+                            offset: [0, 20],
+                            rotate: 5
+                        },
+                        emphasis: {
+                            endLabel: {
+                                color: 'red',
+                                distance: -50,
+                                offset: [0, -20],
+                                rotate: -5
+                            }
+                        }
+                    }],
+                    animationDuration: 10000,
+                    animationDurationUpdate: 500
+                };
+                chart.setOption(option);
 
             })
 

--- a/test/line-endLabel.html
+++ b/test/line-endLabel.html
@@ -354,7 +354,7 @@ under the License.
                 var chart = echarts.init(document.getElementById('main2'));
                 var option = {
                     title: [{
-                        text: 'distance 50, offset [0, 20], rotate 5\nonhover: distance -50, offset [0, -20], rotate -5',
+                        text: 'distance 50, offset [0, 20], rotate 5\nonhover: offset [0, -20], rotate -5',
                         textAlign: 'center',
                         left: '50%',
                         top: 0
@@ -381,7 +381,6 @@ under the License.
                         emphasis: {
                             endLabel: {
                                 color: 'red',
-                                distance: -50,
                                 offset: [0, -20],
                                 rotate: -5
                             }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

`endLabel` options like `rotate` and `offset` were not working for both `normal` and `emphasis` state.

### Fixed issues

- #13878


## Details

### Before: What was the problem?

```js
emphasis: {
    endLabel: {
        offset: [0, -20],
        rotate: -5
    }
}
``` 

This does not work.



### After: How is it fixed in this PR?

It works after fixing.



## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information

`emphasis.distance` is not supported for now. Document changes should be updated.

