### PR TITLE
fix(bar-race): fix when no oldOrder

### DIFF
--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -512,7 +512,7 @@ class BarView extends ChartView {
                  * bars are both out of sight, we don't wish to trigger reorder action
                  * as long as the order in the view doesn't change.
                  */
-                if (!oldOrder[i] || oldOrder[i].ordinalNumber !== newOrder[i].ordinalNumber) {
+                if (!oldOrder || !oldOrder[i] || oldOrder[i].ordinalNumber !== newOrder[i].ordinalNumber) {
                     this.removeOnRenderedListener(api);
 
                     const action = {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

If calling `setOption` with `notMerge`, there is no `oldOrder` so accessing `oldOrder[i]` get error. This PR fixes this problem.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

Call `setOption` with `realtimeSort` and then call `setOption` with `notMerge` as `true`.



### After: How is it fixed in this PR?

Checking `oldOrder` before accessing `oldOrder[i]`.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
