### PR TITLE
Fix/legend auto

### DIFF
--- a/src/component/transform/filterTransform.ts
+++ b/src/component/transform/filterTransform.ts
@@ -17,8 +17,10 @@
 * under the License.
 */
 
-import { DataTransformOption, ExternalDataTransform } from '../../data/helper/transform';
-import { DimensionIndex, OptionDataItem } from '../../util/types';
+import {
+    DataTransformOption, ExternalDataTransform, DataTransformDataItem, ExternalDataTransformResultItem
+} from '../../data/helper/transform';
+import { DimensionIndex } from '../../util/types';
 import { parseConditionalExpression, ConditionalExpressionOption } from '../../util/conditionalExpression';
 import { hasOwn, createHashMap } from 'zrender/src/core/util';
 import { makePrintable, throwError } from '../../util/log';
@@ -41,7 +43,7 @@ export const filterTransform: ExternalDataTransform<FilterTransformOption> = {
         // is better than return the entire raw soruce for user to find the mistake.
 
         const upstream = params.upstream;
-        let rawItem: OptionDataItem;
+        let rawItem: DataTransformDataItem;
 
         const condition = parseConditionalExpression<{ dimIdx: DimensionIndex }>(params.config, {
 
@@ -84,12 +86,12 @@ export const filterTransform: ExternalDataTransform<FilterTransformOption> = {
         for (let i = 0, len = upstream.count(); i < len; i++) {
             rawItem = upstream.getRawDataItem(i);
             if (condition.evaluate()) {
-                resultData.push(rawItem);
+                resultData.push(rawItem as any);
             }
         }
 
         return {
-            data: resultData
+            data: resultData as ExternalDataTransformResultItem['data']
         };
     }
 };

--- a/src/component/transform/sortTransform.ts
+++ b/src/component/transform/sortTransform.ts
@@ -17,7 +17,9 @@
 * under the License.
 */
 
-import { DataTransformOption, ExternalDataTransform } from '../../data/helper/transform';
+import {
+    DataTransformOption, ExternalDataTransform, ExternalDataTransformResultItem
+} from '../../data/helper/transform';
 import {
     DimensionLoose, DimensionIndex, OptionDataValue, SOURCE_FORMAT_ARRAY_ROWS, SOURCE_FORMAT_OBJECT_ROWS
 } from '../../util/types';
@@ -199,7 +201,7 @@ export const sortTransform: ExternalDataTransform<SortTransformOption> = {
         });
 
         return {
-            data: resultData
+            data: resultData as ExternalDataTransformResultItem['data']
         };
     }
 };

--- a/src/data/Source.ts
+++ b/src/data/Source.ts
@@ -287,7 +287,10 @@ function makeEncodeDefine(
         : null;
 }
 
-function detectSourceFormat(data: DatasetOption['source']): SourceFormat {
+/**
+ * Note: An empty array will be detected as `SOURCE_FORMAT_ARRAY_ROWS`.
+ */
+export function detectSourceFormat(data: DatasetOption['source']): SourceFormat {
     let sourceFormat: SourceFormat = SOURCE_FORMAT_UNKNOWN;
 
     if (isTypedArray(data)) {
@@ -322,9 +325,6 @@ function detectSourceFormat(data: DatasetOption['source']): SourceFormat {
                 break;
             }
         }
-    }
-    else if (data != null) {
-        throw new Error('Invalid data');
     }
 
     return sourceFormat;

--- a/src/data/helper/sourceHelper.ts
+++ b/src/data/helper/sourceHelper.ts
@@ -82,31 +82,6 @@ export function resetSourceDefaulter(ecModel: GlobalModel): void {
     innerGlobalModel(ecModel).datasetMap = createHashMap();
 }
 
-// See [DIMENSION_INHERIT_RULE] in `sourceManager.ts`.
-export function inheritSourceMetaRawOption(
-    upstream: Source, // Can be null/undefined
-    newMetaRawOption: SourceMetaRawOption // Can NOT be null/undefined
-): SourceMetaRawOption {
-    const parentMetaRawOption = upstream ? upstream.metaRawOption : null;
-    const seriesLayoutBy = retrieve2(
-        newMetaRawOption.seriesLayoutBy,
-        parentMetaRawOption ? parentMetaRawOption.seriesLayoutBy : null
-    );
-    // sourceHeader and dimensions should use the "detected result" rather than "meta raw".
-    // Consider the case: transform return only "data" but no "dimensions", that should means inherit
-    // dimensions definition from upstream. But the returned data does not contain header line and can not
-    // be used as dimension-detection. In this case we should use "detected dimensions" of upstream directly.
-    const sourceHeader = retrieve2(
-        newMetaRawOption.sourceHeader,
-        upstream ? upstream.startIndex : null
-    );
-    const dimensions = retrieve2(
-        newMetaRawOption.dimensions,
-        upstream ? upstream.dimensionsDefine : null
-    );
-    return { seriesLayoutBy, sourceHeader, dimensions };
-}
-
 /**
  * [The strategy of the arrengment of data dimensions for dataset]:
  * "value way": all axes are non-category axes. So series one by one take

--- a/src/data/helper/sourceManager.ts
+++ b/src/data/helper/sourceManager.ts
@@ -19,7 +19,7 @@
 
 import { DatasetModel } from '../../component/dataset';
 import SeriesModel from '../../model/Series';
-import { setAsPrimitive, map, isTypedArray, assert, each } from 'zrender/src/core/util';
+import { setAsPrimitive, map, isTypedArray, assert, each, retrieve2 } from 'zrender/src/core/util';
 import { SourceMetaRawOption, Source, createSource, cloneSourceShallow } from '../Source';
 import {
     SeriesEncodableModel, OptionSourceData,
@@ -27,8 +27,7 @@ import {
     SourceFormat, SeriesLayoutBy, OptionSourceHeader, DimensionDefinitionLoose
 } from '../../util/types';
 import {
-    querySeriesUpstreamDatasetModel, queryDatasetUpstreamDatasetModels,
-    inheritSourceMetaRawOption
+    querySeriesUpstreamDatasetModel, queryDatasetUpstreamDatasetModels
 } from './sourceHelper';
 import { applyDataTransform } from './transform';
 
@@ -192,7 +191,7 @@ export class SourceManager {
             const seriesModel = sourceHost as SeriesEncodableModel;
             let data;
             let sourceFormat: SourceFormat;
-            let upSource;
+            let upSource: Source;
 
             // Has upstream dataset
             if (hasUpstream) {
@@ -212,14 +211,27 @@ export class SourceManager {
             }
 
             // See [REQUIREMENT_MEMO], merge settings on series and parent dataset if it is root.
-            const thisMetaRawOption = inheritSourceMetaRawOption(
-                upSource,
-                this._getSourceMetaRawOption()
+            const newMetaRawOption = this._getSourceMetaRawOption();
+            const upMetaRawOption = upSource ? upSource.metaRawOption : null;
+            const seriesLayoutBy = retrieve2(
+                newMetaRawOption.seriesLayoutBy,
+                upMetaRawOption ? upMetaRawOption.seriesLayoutBy : null
+            );
+            const sourceHeader = retrieve2(
+                newMetaRawOption.sourceHeader,
+                upMetaRawOption ? upMetaRawOption.sourceHeader : null
+            );
+            // Note here we should not use `upSource.dimensionsDefine`. Consider the case:
+            // `upSource.dimensionsDefine` is detected by `seriesLayoutBy: 'column'`,
+            // but series need `seriesLayoutBy: 'row'`.
+            const dimensions = retrieve2(
+                newMetaRawOption.dimensions,
+                upMetaRawOption ? upMetaRawOption.dimensions : null
             );
 
             resultSourceList = [createSource(
                 data,
-                thisMetaRawOption,
+                { seriesLayoutBy, sourceHeader, dimensions },
                 sourceFormat,
                 seriesModel.get('encode', true)
             )];

--- a/test/legend-feature.html
+++ b/test/legend-feature.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+
+
+
+        <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+
+
+            option = {
+                legend: {},
+                tooltip: {},
+                dataset: {
+                    source: [
+                        ['product', '2012', '2013', '2014', '2015'],
+                        ['AAA', 41.1, 30.4, 65.1, 53.3],
+                        ['BBB', 86.5, 92.1, 85.7, 83.1],
+                        ['CCC', 24.1, 67.2, 79.5, 86.4]
+                    ]
+                },
+                xAxis: [
+                    {type: 'category', gridIndex: 0},
+                    {type: 'category', gridIndex: 1}
+                ],
+                yAxis: [
+                    {gridIndex: 0},
+                    {gridIndex: 1}
+                ],
+                grid: [
+                    {bottom: '55%'},
+                    {top: '55%'}
+                ],
+                series: [
+                    // These series are in the first grid.
+                    {type: 'bar', seriesLayoutBy: 'row'},
+                    {type: 'bar', seriesLayoutBy: 'row'},
+                    // These series are in the second grid.
+                    {type: 'bar', xAxisIndex: 1, yAxisIndex: 1},
+                    {type: 'bar', xAxisIndex: 1, yAxisIndex: 1},
+                    {type: 'bar', xAxisIndex: 1, yAxisIndex: 1}
+                ]
+            };
+
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'The legend should be: ',
+                    '"AAA", "BBB", "2012", "2013", "2014"'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+

--- a/test/ut/core/utHelper.ts
+++ b/test/ut/core/utHelper.ts
@@ -27,6 +27,7 @@ import {
 import { ComponentMainType } from '../../../src/util/types';
 import Group from 'zrender/src/graphic/Group';
 import Element from 'zrender/src/Element';
+import GlobalModel from '../../../src/model/Global';
 
 
 export function createChart(params?: {
@@ -137,9 +138,13 @@ export function getViewGroup(
     mainType: ComponentMainType,
     index?: number
 ): Group {
-    const component = chart.getModel().getComponent(mainType, index);
+    const component = getECModel(chart).getComponent(mainType, index);
     return component ? chart[
         mainType === 'series' ? '_chartsMap' : '_componentsMap'
     ][component.__viewId].group : null;
 }
 
+export function getECModel(chart: EChartsType): GlobalModel {
+    // @ts-ignore
+    return chart.getModel();
+}

--- a/test/ut/spec/component/dataZoom/helper.test.ts
+++ b/test/ut/spec/component/dataZoom/helper.test.ts
@@ -19,7 +19,7 @@
 */
 
 import { findEffectedDataZooms } from '../../../../../src/component/dataZoom/helper';
-import { createChart } from '../../../core/utHelper';
+import { createChart, getECModel } from '../../../core/utHelper';
 import { EChartsType } from '../../../../../src/echarts';
 
 
@@ -50,12 +50,12 @@ describe('dataZoom/helper', function () {
             });
 
             const payload = { type: 'dataZoom', dataZoomIndex: 0 };
-            const dzModels = findEffectedDataZooms(chart.getModel(), payload);
+            const dzModels = findEffectedDataZooms(getECModel(chart), payload);
 
             expect(dzModels.length === 3);
-            expect(dzModels[0] === chart.getModel().getComponent('dataZoom', 0)).toEqual(true);
-            expect(dzModels[1] === chart.getModel().getComponent('dataZoom', 3)).toEqual(true);
-            expect(dzModels[2] === chart.getModel().getComponent('dataZoom', 2)).toEqual(true);
+            expect(dzModels[0] === getECModel(chart).getComponent('dataZoom', 0)).toEqual(true);
+            expect(dzModels[1] === getECModel(chart).getComponent('dataZoom', 3)).toEqual(true);
+            expect(dzModels[2] === getECModel(chart).getComponent('dataZoom', 2)).toEqual(true);
         });
 
         it('findLinkedNodes_crossXY', function () {
@@ -72,13 +72,13 @@ describe('dataZoom/helper', function () {
             });
 
             const payload = { type: 'dataZoom', dataZoomIndex: 0 };
-            const dzModels = findEffectedDataZooms(chart.getModel(), payload);
+            const dzModels = findEffectedDataZooms(getECModel(chart), payload);
 
             expect(dzModels.length === 4);
-            expect(dzModels[0] === chart.getModel().getComponent('dataZoom', 0)).toEqual(true);
-            expect(dzModels[1] === chart.getModel().getComponent('dataZoom', 1)).toEqual(true);
-            expect(dzModels[2] === chart.getModel().getComponent('dataZoom', 2)).toEqual(true);
-            expect(dzModels[3] === chart.getModel().getComponent('dataZoom', 3)).toEqual(true);
+            expect(dzModels[0] === getECModel(chart).getComponent('dataZoom', 0)).toEqual(true);
+            expect(dzModels[1] === getECModel(chart).getComponent('dataZoom', 1)).toEqual(true);
+            expect(dzModels[2] === getECModel(chart).getComponent('dataZoom', 2)).toEqual(true);
+            expect(dzModels[3] === getECModel(chart).getComponent('dataZoom', 3)).toEqual(true);
         });
 
         it('findLinkedNodes_emptySourceModel', function () {
@@ -95,7 +95,7 @@ describe('dataZoom/helper', function () {
             });
 
             const payload = { type: 'other' };
-            const dzModels = findEffectedDataZooms(chart.getModel(), payload);
+            const dzModels = findEffectedDataZooms(getECModel(chart), payload);
 
             expect(dzModels.length === 0);
         });

--- a/test/ut/spec/component/graphic/setOption.test.ts
+++ b/test/ut/spec/component/graphic/setOption.test.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import { createChart, getGraphicElements } from '../../../core/utHelper';
+import { createChart, getGraphicElements, getECModel } from '../../../core/utHelper';
 // import { imageURI } from './setOptionImageURI';
 import { EChartsType } from '../../../../../src/echarts';
 import Element from 'zrender/src/Element';
@@ -338,8 +338,8 @@ describe('graphic_setOption', function () {
                 ]
             });
 
-            expect(!!chart.getModel().getComponent('graphic')).toEqual(true);
-            expect(chart.getModel().getComponent('graphic', 1) == null).toEqual(true);
+            expect(!!getECModel(chart).getComponent('graphic')).toEqual(true);
+            expect(getECModel(chart).getComponent('graphic', 1) == null).toEqual(true);
         });
 
 

--- a/test/ut/spec/component/visualMap/setOption.test.ts
+++ b/test/ut/spec/component/visualMap/setOption.test.ts
@@ -18,7 +18,7 @@
 * under the License.
 */
 
-import { createChart } from '../../../core/utHelper';
+import { createChart, getECModel } from '../../../core/utHelper';
 import { EChartsType } from '../../../../../src/echarts';
 import { EChartsFullOption } from '../../../../../src/option';
 import { ContinousVisualMapOption } from '../../../../../src/component/visualMap/ContinuousModel';
@@ -256,7 +256,7 @@ describe('vsiaulMap_setOption', function () {
             ]
         });
 
-        const ecModel = chart.getModel();
+        const ecModel = getECModel(chart);
 
         function getVisual(idx: number, visualType: 'color' | 'opacity' | 'symbol') {
             return (ecModel.getComponent('visualMap', idx) as VisualMapModel)

--- a/test/ut/spec/data/dataTransform.test.ts
+++ b/test/ut/spec/data/dataTransform.test.ts
@@ -1,0 +1,185 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '../../../../src/echarts';
+import { createChart, removeChart, getECModel } from '../../core/utHelper';
+import { EChartsFullOption } from '../../../../src/option';
+import { retrieveRawValue } from '../../../../src/data/helper/dataProvider';
+
+
+describe('dataTransform', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart({
+            width: 200,
+            height: 150
+        });
+    });
+
+    afterEach(function () {
+        removeChart(chart);
+    });
+
+    function makeDatasetSourceDetection() {
+        return [
+            ['product', '2012', '2013', '2014', '2015'],
+            ['AAA', 41.1, 30.4, 65.1, 53.3],
+            ['BBB', 86.5, 92.1, 85.7, 83.1],
+            ['CCC', 24.1, 67.2, 79.5, 86.4]
+        ];
+    }
+
+    function makeDatasetSourceNonDetectionByRow() {
+        return {
+            dimensions: ['2012', '2013', '2014', '2015'],
+            source: [
+                [41.1, 30.4, 65.1, 53.3],
+                [86.5, 92.1, 85.7, 83.1],
+                [24.1, 67.2, 79.5, 86.4]
+            ]
+        };
+    }
+
+    it('forbid_seriesLayoutBy_row', function () {
+        const option: EChartsFullOption = {
+            dataset: [{
+                source: makeDatasetSourceDetection(),
+                // This config should cause error thrown.
+                seriesLayoutBy: 'row'
+            }, {
+                transform: { type: 'filter', config: { dimension: 0, ne: '' } }
+            }],
+            xAxis: { type: 'category' },
+            yAxis: {},
+            series: { type: 'bar', datasetIndex: 1 }
+        };
+
+        expect(() => {
+            chart.setOption(option);
+        }).toThrowError(/column/);
+    });
+
+    it('seriesLayoutBy_changed_no_transform', function () {
+        const option: EChartsFullOption = {
+            dataset: {
+                source: makeDatasetSourceDetection()
+            },
+            xAxis: { type: 'category' },
+            yAxis: {},
+            series: { type: 'bar', seriesLayoutBy: 'row' }
+        };
+
+        chart.setOption(option);
+        const listData = getECModel(chart).getSeries()[0].getData();
+        expect(listData.getDimension(1)).toEqual('AAA');
+        expect(listData.getDimension(2)).toEqual('BBB');
+        expect(listData.getDimension(3)).toEqual('CCC');
+    });
+
+    [{
+        transform:
+            { type: 'filter', config: { dimension: 'product', '!=': 'XXX' } }
+    }, {
+        transform: [
+            { type: 'filter', config: { dimension: 'product', '!=': 'XXX' } },
+            { type: 'filter', config: { dimension: 'product', '!=': 'XXX' } }
+        ]
+    }].forEach((dataset1, itIdx) => {
+        it(`seriesLayoutBy_changed_transform_detection_${itIdx}`, function () {
+            const option: EChartsFullOption = {
+                dataset: [{
+                    source: makeDatasetSourceDetection()
+                }, dataset1],
+                xAxis: { type: 'category' },
+                yAxis: {},
+                series: { type: 'bar', datasetIndex: 1, seriesLayoutBy: 'row' }
+            };
+
+            chart.setOption(option);
+            const listData = getECModel(chart).getSeries()[0].getData();
+            expect(listData.getDimension(1)).toEqual('AAA');
+            expect(listData.getDimension(2)).toEqual('BBB');
+            expect(listData.getDimension(3)).toEqual('CCC');
+            expect(listData.get('product', 0)).toEqual(0);
+            expect(retrieveRawValue(listData, 0, 'product')).toEqual('2012');
+            expect(listData.get('product', 1)).toEqual(1);
+            expect(retrieveRawValue(listData, 1, 'product')).toEqual('2013');
+        });
+    });
+
+    [{
+        transform:
+            { type: 'filter', config: { dimension: 0, '!=': 'XXX' } }
+    }, {
+        transform: [
+            { type: 'filter', config: { dimension: 0, '!=': 'XXX' } },
+            { type: 'filter', config: { dimension: 0, '!=': 'XXX' } }
+        ]
+    }].forEach((dataset1, itIdx) => {
+        it(`seriesLayoutBy_changed_transform_non_detection_${itIdx}`, function () {
+            const sourceWrap = makeDatasetSourceNonDetectionByRow();
+            const option: EChartsFullOption = {
+                dataset: [{
+                    dimensions: sourceWrap.dimensions,
+                    source: sourceWrap.source
+                }, dataset1],
+                xAxis: {},
+                yAxis: {},
+                series: { type: 'bar', datasetIndex: 1, seriesLayoutBy: 'row' }
+            };
+
+            chart.setOption(option);
+            const listData = getECModel(chart).getSeries()[0].getData();
+            expect(listData.get(listData.getDimension(0), 0)).toEqual(41.1);
+            expect(listData.get(listData.getDimension(0), 1)).toEqual(30.4);
+        });
+    });
+
+    [{
+        transform:
+            { type: 'filter', config: { dimension: '2012', '!=': 'XXX' } }
+    }, {
+        transform: [
+            { type: 'filter', config: { dimension: '2012', '!=': 'XXX' } },
+            { type: 'filter', config: { dimension: '2012', '!=': 'XXX' } }
+        ]
+    }].forEach((dataset1, itIdx) => {
+        it(`inherit_detected_dimensions_${itIdx}`, function () {
+            const option: EChartsFullOption = {
+                dataset: [{
+                    source: makeDatasetSourceDetection()
+                }, dataset1],
+                xAxis: { type: 'category' },
+                yAxis: {},
+                series: { type: 'bar', datasetIndex: 1 }
+            };
+
+            chart.setOption(option);
+            const listData = getECModel(chart).getSeries()[0].getData();
+            expect(listData.getDimension(0)).toEqual('product');
+            expect(listData.getDimension(1)).toEqual('2012');
+            expect(listData.getDimension(2)).toEqual('2013');
+        });
+    });
+
+
+});
+

--- a/test/ut/spec/model/Global.test.ts
+++ b/test/ut/spec/model/Global.test.ts
@@ -19,7 +19,7 @@
 */
 
 import { EChartsType } from '../../../../src/echarts';
-import { createChart } from '../../core/utHelper';
+import { createChart, getECModel } from '../../core/utHelper';
 import { ComponentMainType, ParsedValue } from '../../../../src/util/types';
 import SeriesModel from '../../../../src/model/Series';
 import ComponentModel from '../../../../src/model/Component';
@@ -39,11 +39,11 @@ describe('modelAndOptionMapping', function () {
     }
 
     function getSeries(chart: EChartsType, seriesIndex: number): SeriesModel {
-        return chart.getModel().getComponent('series', seriesIndex) as SeriesModel;
+        return getECModel(chart).getComponent('series', seriesIndex) as SeriesModel;
     }
 
     function getModel(chart: EChartsType, type: ComponentMainType, index: number): ComponentModel {
-        return chart.getModel().getComponent(type, index);
+        return getECModel(chart).getComponent(type, index);
     }
 
     function countSeries(chart: EChartsType): number {
@@ -54,7 +54,7 @@ describe('modelAndOptionMapping', function () {
         // FIXME
         // access private
         // @ts-ignore
-        return chart.getModel()._componentsMap.get(type).length;
+        return getECModel(chart)._componentsMap.get(type).length;
     }
 
     function getChartView(chart: EChartsType, series: SeriesModel): ChartView {
@@ -801,14 +801,14 @@ describe('modelAndOptionMapping', function () {
                 ]
             };
             chart.setOption(option);
-            expect(chart.getModel().option.backgroundColor).toEqual('rgba(1,1,1,1)');
+            expect(getECModel(chart).option.backgroundColor).toEqual('rgba(1,1,1,1)');
 
             // Not merge
             chart.setOption({
                 backgroundColor: '#fff'
             }, true);
 
-            expect(chart.getModel().option.backgroundColor).toEqual('#fff');
+            expect(getECModel(chart).option.backgroundColor).toEqual('#fff');
         });
 
         it('innerId', function () {

--- a/test/ut/spec/model/timelineMediaOptions.test.ts
+++ b/test/ut/spec/model/timelineMediaOptions.test.ts
@@ -23,7 +23,7 @@ import SeriesModel from '../../../../src/model/Series';
 import { ParsedValue } from '../../../../src/util/types';
 import { LegendOption } from '../../../../src/component/legend/LegendModel';
 import TimelineModel from '../../../../src/component/timeline/TimelineModel';
-import { createChart } from '../../core/utHelper';
+import { createChart, getECModel } from '../../core/utHelper';
 import { EChartsFullOption } from '../../../../src/option';
 
 
@@ -33,13 +33,13 @@ describe('timelineMediaOptions', function () {
         return getSeries(chart, seriesIndex).getData().get('y', 0);
     }
     function getSeries(chart: EChartsType, seriesIndex: number): SeriesModel {
-        return chart.getModel().getComponent('series', seriesIndex) as SeriesModel;
+        return getECModel(chart).getComponent('series', seriesIndex) as SeriesModel;
     }
     function getLegendOption(chart: EChartsType): LegendOption {
-        return chart.getModel().getComponent('legend', 0).option;
+        return getECModel(chart).getComponent('legend', 0).option;
     }
     function getTimelineComponent(chart: EChartsType): TimelineModel {
-        return chart.getModel().getComponent('timeline', 0) as TimelineModel;
+        return getECModel(chart).getComponent('timeline', 0) as TimelineModel;
     }
 
     let chart: EChartsType;
@@ -388,7 +388,7 @@ describe('timelineMediaOptions', function () {
             };
             chart.setOption(option);
 
-            let ecModel = chart.getModel();
+            let ecModel = getECModel(chart);
             expect(getData0(chart, 0)).toEqual(1111);
             expect(getData0(chart, 1)).toEqual(2222);
 
@@ -410,7 +410,7 @@ describe('timelineMediaOptions', function () {
                 }]
             });
 
-            ecModel = chart.getModel();
+            ecModel = getECModel(chart);
             const optionGotten = ecModel.getOption();
             expect(optionGotten.backgroundColor).toEqual('#987654');
             expect(getData0(chart, 0)).toEqual(1111);

--- a/test/ut/spec/scale/interval.test.ts
+++ b/test/ut/spec/scale/interval.test.ts
@@ -18,7 +18,7 @@
 * under the License.
 */
 
-import { createChart, isValueFinite } from '../../core/utHelper';
+import { createChart, isValueFinite, getECModel } from '../../core/utHelper';
 import { EChartsType } from '../../../../src/echarts';
 import CartesianAxisModel from '../../../../src/coord/cartesian/AxisModel';
 import IntervalScale from '../../../../src/scale/Interval';
@@ -57,7 +57,7 @@ describe('scale_interval', function () {
                 series: [{type: 'line', data: []}]
             });
 
-            const yAxis = chart.getModel().getComponent('yAxis', 0) as CartesianAxisModel;
+            const yAxis = getECModel(chart).getComponent('yAxis', 0) as CartesianAxisModel;
             const scale = yAxis.axis.scale;
             const ticks = scale.getTicks();
 
@@ -91,7 +91,7 @@ describe('scale_interval', function () {
                 ]
             });
 
-            const yAxis = chart.getModel().getComponent('yAxis', 0) as CartesianAxisModel;
+            const yAxis = getECModel(chart).getComponent('yAxis', 0) as CartesianAxisModel;
             const scale = yAxis.axis.scale as IntervalScale;
             const ticks = scale.getTicks();
             const labels = yAxis.axis.getViewLabels().map(function (item) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

fix: 
1. series data should not inherit its parents detected dimensions, because the detected dimensions might be based on different `seriesLayoutBy`. 
2. data-transform should fill back the detected dimensions to this result data, so that the downstream series can use the data in `seriesLayoutBy: 'row'`. 
3. fix #13915 (caused by 1)
4. fix some ts type.