### PR TITLE
fix(Gauge): pointer.offsetCenter doesn't work without icon #13962

### DIFF
--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -356,6 +356,8 @@ class GaugeView extends ChartView {
             const pointerLength = parsePercent(pointerModel.get('length'), posInfo.r);
             const pointerStr = seriesModel.get(['pointer', 'icon']);
             const pointerOffset = pointerModel.get('offsetCenter');
+            const pointerOffsetX = parsePercent(pointerOffset[0], posInfo.r);
+            const pointerOffsetY = parsePercent(pointerOffset[1], posInfo.r);
             const pointerKeepAspect = pointerModel.get('keepAspect');
 
             let pointer;
@@ -363,8 +365,8 @@ class GaugeView extends ChartView {
             if (pointerStr) {
                 pointer = createSymbol(
                     pointerStr,
-                    parsePercent(pointerOffset[0], posInfo.r) - pointerWidth / 2,
-                    parsePercent(pointerOffset[1], posInfo.r) - pointerLength,
+                    pointerOffsetX - pointerWidth / 2,
+                    pointerOffsetY - pointerLength,
                     pointerWidth,
                     pointerLength,
                     null,
@@ -375,8 +377,10 @@ class GaugeView extends ChartView {
                 pointer = new PointerPath({
                     shape: {
                         angle: -Math.PI / 2,
-                        width: parsePercent(pointerModel.get('width'), posInfo.r),
-                        r: parsePercent(pointerModel.get('length'), posInfo.r)
+                        width: pointerWidth,
+                        r: pointerLength,
+                        x: pointerOffsetX,
+                        y: pointerOffsetY
                     }
                 });
             }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
#13962 
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
- pointer.offsetCenter doesn't work without pointer.icon

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?
- add the offsetCenter to default icon of poiner

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
