### PR TITLE
fix(loading): showLoading align center

### DIFF
--- a/src/loading/default.ts
+++ b/src/loading/default.ts
@@ -51,7 +51,7 @@ export default function defaultLoading(
     zrUtil.defaults(opts, {
         text: 'loading',
         textColor: '#000',
-        fontSize: '12px',
+        fontSize: 12,
         maskColor: 'rgba(255, 255, 255, 0.8)',
         showSpinner: true,
         color: '#5470c6',
@@ -68,7 +68,8 @@ export default function defaultLoading(
         z: 10000
     });
     group.add(mask);
-    const font = opts.fontSize + ' sans-serif';
+
+    const font = `${parseInt(opts.fontSize + '', 10)}px sans-serif`;
     const labelRect = new graphic.Rect({
         style: {
             fill: 'none'
@@ -127,8 +128,11 @@ export default function defaultLoading(
         // cx = (containerWidth - arcDiameter - textDistance - textWidth) / 2
         // textDistance needs to be calculated when both animation and text exist
         const cx = (api.getWidth() - r * 2 - (opts.showSpinner && textWidth ? 10 : 0) - textWidth) / 2
+            - (opts.showSpinner && textWidth ? 0 : 5 + textWidth / 2)
             // only show the text
-            - (opts.showSpinner ? 0 : textWidth / 2);
+            + (opts.showSpinner ? 0 : textWidth / 2)
+            // only show the spinner
+            + (textWidth ? 0 : r);
         const cy = api.getHeight() / 2;
         opts.showSpinner && arc.setShape({
             cx: cx,

--- a/src/loading/default.ts
+++ b/src/loading/default.ts
@@ -21,7 +21,6 @@ import * as zrUtil from 'zrender/src/core/util';
 import * as graphic from '../util/graphic';
 import { LoadingEffect } from '../util/types';
 import ExtensionAPI from '../core/ExtensionAPI';
-import * as textContain from 'zrender/src/contain/text';
 
 const PI = Math.PI;
 
@@ -45,6 +44,9 @@ export default function defaultLoading(
         spinnerRadius?: number;
         lineWidth?: number;
         fontSize?: number;
+        fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | number;
+        fontStyle?: 'normal' | 'italic' | 'oblique';
+        fontFamily?: string
     }
 ): LoadingEffect {
     opts = opts || {};
@@ -52,6 +54,9 @@ export default function defaultLoading(
         text: 'loading',
         textColor: '#000',
         fontSize: 12,
+        fontWeight: 'normal',
+        fontStyle: 'normal',
+        fontFamily: 'sans-serif',
         maskColor: 'rgba(255, 255, 255, 0.8)',
         showSpinner: true,
         color: '#5470c6',
@@ -69,18 +74,22 @@ export default function defaultLoading(
     });
     group.add(mask);
 
-    const font = `${parseInt(opts.fontSize + '', 10)}px sans-serif`;
+    const textContent = new graphic.Text({
+        style: {
+            text: opts.text,
+            fill: opts.textColor,
+            fontSize: opts.fontSize,
+            fontWeight: opts.fontWeight,
+            fontStyle: opts.fontStyle,
+            fontFamily: opts.fontFamily
+        }
+    });
+
     const labelRect = new graphic.Rect({
         style: {
             fill: 'none'
         },
-        textContent: new graphic.Text({
-            style: {
-                text: opts.text,
-                fill: opts.textColor,
-                font: font
-            }
-        }),
+        textContent: textContent,
         textConfig: {
             position: 'right',
             distance: 10
@@ -123,7 +132,7 @@ export default function defaultLoading(
 
     // Inject resize
     group.resize = function () {
-        const textWidth = textContain.getWidth(opts.text, font);
+        const textWidth = textContent.getBoundingRect().width;
         const r = opts.showSpinner ? opts.spinnerRadius : 0;
         // cx = (containerWidth - arcDiameter - textDistance - textWidth) / 2
         // textDistance needs to be calculated when both animation and text exist

--- a/test/loading.html
+++ b/test/loading.html
@@ -48,6 +48,8 @@ under the License.
         <div class="chart" id="main3"></div>
         <h1>fontSzie: 25, arcRadius: 12, lineWidth: 8</h1>
         <div class="chart" id="main4"></div>
+        <h1>fontSzie: 25, fontWeight: 'bolder', fontFamily: 'Microsoft YaHei', fontStyle: 'italic'</h1>
+        <div class="chart" id="main5"></div>
         <script>
 
             require([
@@ -70,6 +72,7 @@ under the License.
                     fontSize: 20,
                     showSpinner: false
                 });
+
                 var chart3 = echarts.init(document.getElementById('main3'));
                 chart3.showLoading({
                     text: '暂时没有数据',
@@ -81,11 +84,27 @@ under the License.
                     lineWidth: 8,
                     zlevel: 0
                 });
+
                 var chart4 = echarts.init(document.getElementById('main4'));
                 chart4.showLoading({
                     text: '暂时没有数据',
                     textColor: '#000',
                     fontSize: 25,
+                    maskColor: 'rgba(255, 255, 255, 0.8)',
+                    color: '#c23531',
+                    arcRadius: 20,
+                    lineWidth: 8,
+                    zlevel: 0
+                });
+
+                var chart5 = echarts.init(document.getElementById('main5'));
+                chart5.showLoading({
+                    text: '暂时没有数据',
+                    textColor: '#000',
+                    fontSize: 25,
+                    fontWeight: 'bolder', 
+                    fontFamily: 'Microsoft YaHei', 
+                    fontStyle: 'italic',
                     maskColor: 'rgba(255, 255, 255, 0.8)',
                     color: '#c23531',
                     arcRadius: 20,

--- a/test/loading.html
+++ b/test/loading.html
@@ -46,6 +46,8 @@ under the License.
         <div class="chart" id="main2"></div>
         <h1>fontSzie: 25px, arcRadius: 12, lineWidth: 8</h1>
         <div class="chart" id="main3"></div>
+        <h1>fontSzie: 25, arcRadius: 12, lineWidth: 8</h1>
+        <div class="chart" id="main4"></div>
         <script>
 
             require([
@@ -57,21 +59,36 @@ under the License.
 
                 var chart1 = echarts.init(document.getElementById('main1'));
                 chart1.showLoading({
-                    text: ''
+                    text: '',
+                    spinnerRadius: 50
                 });
 
                 var chart2 = echarts.init(document.getElementById('main2'));
                 chart2.showLoading({
-                    showAnimation: false
+                    text: '没有 spinner 时，文字需要居中显示',
+                    textColor: '#000',
+                    fontSize: 20,
+                    showSpinner: false
                 });
                 var chart3 = echarts.init(document.getElementById('main3'));
                 chart3.showLoading({
-                    text: '暂无数据',
+                    text: '暂时没有数据',
                     textColor: '#000',
                     fontSize: '25px',
                     maskColor: 'rgba(255, 255, 255, 0.8)',
                     color: '#c23531',
-                    arcRadius: 12,
+                    arcRadius: 20,
+                    lineWidth: 8,
+                    zlevel: 0
+                });
+                var chart4 = echarts.init(document.getElementById('main4'));
+                chart4.showLoading({
+                    text: '暂时没有数据',
+                    textColor: '#000',
+                    fontSize: 25,
+                    maskColor: 'rgba(255, 255, 255, 0.8)',
+                    color: '#c23531',
+                    arcRadius: 20,
                     lineWidth: 8,
                     zlevel: 0
                 });
@@ -80,6 +97,7 @@ under the License.
                     chart1.resize();
                     chart2.resize();
                     chart3.resize();
+                    chart4.resize();
                 };
             });
         </script>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?
- bugfix: the showLoading.fontSize with number type doesn't work  (#13892)

- bugfix: showLoading align center (#13893)
1. show spinner and text
2. only show spinner
3. only show text

- feature: showLoading support fontFamily/fontWeight/fontStyle

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
#13892 
#13893 
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
