### PR TITLE
Provide Better APIs for extensions like ECharts GL, WordCloud, LiquidFill

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -167,6 +167,7 @@ async function build(configs) {
             chalk.cyan(singleConfig.input)
         );
 
+        console.time('rollup build');
         const bundle = await rollup.rollup(singleConfig);
 
         for (let output of singleConfig.output) {
@@ -178,9 +179,8 @@ async function build(configs) {
 
             await bundle.write(output);
 
-            console.time('rollup build');
-            console.timeEnd('rollup build');
         };
+        console.timeEnd('rollup build');
 
         checkBundleCode(singleConfig);
     }

--- a/build/pre-publish.js
+++ b/build/pre-publish.js
@@ -220,8 +220,8 @@ async function tsCompile(compilerOptionsOverride, srcPathList) {
 
     let compilerOptions = {
         ...tsConfig.compilerOptions,
-        ...compilerOptionsOverride
-        // sourceMap: true
+        ...compilerOptionsOverride,
+        sourceMap: false
     };
 
     runTsCompile(ts, compilerOptions, srcPathList);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lib/echarts.js",
     "lib/chart/*.js",
     "lib/component/*.js",
+    "extension/**/*.js",
     "theme/*.js",
     "i18n/*.js"
   ],

--- a/src/component/timeline/SliderTimelineView.ts
+++ b/src/component/timeline/SliderTimelineView.ts
@@ -30,7 +30,6 @@ import GlobalModel from '../../model/Global';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import { merge, each, extend, isString, bind, defaults, retrieve2 } from 'zrender/src/core/util';
 import SliderTimelineModel from './SliderTimelineModel';
-import ComponentView from '../../view/Component';
 import { LayoutOrient, ZRTextAlign, ZRTextVerticalAlign, ZRElementEvent, ScaleTick } from '../../util/types';
 import TimelineModel, { TimelineDataItemOption, TimelineCheckpointStyle } from './TimelineModel';
 import { TimelineChangePayload, TimelinePlayChangePayload } from './timelineAction';

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -2811,7 +2811,9 @@ export function extendComponentModel(proto: object): ComponentModel {
     //     let classType = parseClassType(superClass);
     //     Clazz = ComponentModel.getClass(classType.main, classType.sub, true);
     // }
-    return (ComponentModel as ComponentModelConstructor).extend(proto) as any;
+    const Model = (ComponentModel as ComponentModelConstructor).extend(proto) as any;
+    ComponentModel.registerClass(Model);
+    return Model;
 }
 
 export function extendComponentView(proto: object): ChartView {
@@ -2820,7 +2822,9 @@ export function extendComponentView(proto: object): ChartView {
     //     let classType = parseClassType(superClass);
     //     Clazz = ComponentView.getClass(classType.main, classType.sub, true);
     // }
-    return (ComponentView as ComponentViewConstructor).extend(proto) as any;
+    const View = (ComponentView as ComponentViewConstructor).extend(proto) as any;
+    ComponentView.registerClass(View);
+    return View;
 }
 
 export function extendSeriesModel(proto: object): SeriesModel {
@@ -2830,7 +2834,9 @@ export function extendSeriesModel(proto: object): SeriesModel {
     //     let classType = parseClassType(superClass);
     //     Clazz = ComponentModel.getClass(classType.main, classType.sub, true);
     // }
-    return (SeriesModel as SeriesModelConstructor).extend(proto) as any;
+    const Model = (SeriesModel as SeriesModelConstructor).extend(proto) as any;
+    SeriesModel.registerClass(Model);
+    return Model;
 }
 
 export function extendChartView(proto: object): ChartView {
@@ -2840,7 +2846,9 @@ export function extendChartView(proto: object): ChartView {
     //     let classType = parseClassType(superClass);
     //     Clazz = ChartView.getClass(classType.main, true);
     // }
-    return (ChartView as ChartViewConstructor).extend(proto) as any;
+    const View = (ChartView as ChartViewConstructor).extend(proto) as any;
+    ChartView.registerClass(View);
+    return View;
 }
 
 /**

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -2805,52 +2805,6 @@ export function registerLoading(
     loadingEffects[name] = loadingFx;
 }
 
-export function extendComponentModel(proto: object): ComponentModel {
-    // let Clazz = ComponentModel;
-    // if (superClass) {
-    //     let classType = parseClassType(superClass);
-    //     Clazz = ComponentModel.getClass(classType.main, classType.sub, true);
-    // }
-    const Model = (ComponentModel as ComponentModelConstructor).extend(proto) as any;
-    ComponentModel.registerClass(Model);
-    return Model;
-}
-
-export function extendComponentView(proto: object): ChartView {
-    // let Clazz = ComponentView;
-    // if (superClass) {
-    //     let classType = parseClassType(superClass);
-    //     Clazz = ComponentView.getClass(classType.main, classType.sub, true);
-    // }
-    const View = (ComponentView as ComponentViewConstructor).extend(proto) as any;
-    ComponentView.registerClass(View);
-    return View;
-}
-
-export function extendSeriesModel(proto: object): SeriesModel {
-    // let Clazz = SeriesModel;
-    // if (superClass) {
-    //     superClass = 'series.' + superClass.replace('series.', '');
-    //     let classType = parseClassType(superClass);
-    //     Clazz = ComponentModel.getClass(classType.main, classType.sub, true);
-    // }
-    const Model = (SeriesModel as SeriesModelConstructor).extend(proto) as any;
-    SeriesModel.registerClass(Model);
-    return Model;
-}
-
-export function extendChartView(proto: object): ChartView {
-    // let Clazz = ChartView;
-    // if (superClass) {
-    //     superClass = superClass.replace('series.', '');
-    //     let classType = parseClassType(superClass);
-    //     Clazz = ChartView.getClass(classType.main, true);
-    // }
-    const View = (ChartView as ChartViewConstructor).extend(proto) as any;
-    ChartView.registerClass(View);
-    return View;
-}
-
 /**
  * ZRender need a canvas context to do measureText.
  * But in node environment canvas may be created by node-canvas.

--- a/src/export/api.ts
+++ b/src/export/api.ts
@@ -17,6 +17,14 @@
 * under the License.
 */
 
+// These APIs are for more advanced usages
+// For example extend charts and components, creating graphic elements, formatting.
+import ComponentModel, { ComponentModelConstructor } from '../model/Component';
+import ComponentView, { ComponentViewConstructor } from '../view/Component';
+import SeriesModel, { SeriesModelConstructor } from '../model/Series';
+import ChartView, { ChartViewConstructor } from '../view/Chart';
+
+
 // Provide utilities API in echarts. It will be in echarts namespace.
 // Like echarts.util, echarts.graphic
 export * as zrender from 'zrender/src/zrender';
@@ -30,14 +38,7 @@ export * as helper from './api/helper';
 
 export {use} from '../extension';
 
-// Only for GL
-export {brushSingle as innerDrawElementOnCanvas} from 'zrender/src/canvas/graphic';
-
-export {default as List} from '../data/List';
-export {default as Model} from '../model/Model';
-export {default as Axis} from '../coord/Axis';
-export {default as env} from 'zrender/src/core/env';
-
+//////////////// Helper Methods /////////////////////
 export {default as parseGeoJSON} from '../coord/geo/parseGeoJson';
 export {default as parseGeoJson} from '../coord/geo/parseGeoJson';
 
@@ -48,3 +49,52 @@ export * as graphic from './api/graphic';
 export * as format from './api/format';
 
 export * as util from './api/util';
+
+export {default as env} from 'zrender/src/core/env';
+
+//////////////// Export for Exension Usage ////////////////
+export {default as List} from '../data/List';
+export {default as Model} from '../model/Model';
+export {default as Axis} from '../coord/Axis';
+
+export {
+    ComponentModel,
+    ComponentView,
+    SeriesModel,
+    ChartView
+};
+
+// Only for GL
+export {brushSingle as innerDrawElementOnCanvas} from 'zrender/src/canvas/graphic';
+
+
+//////////////// Deprecated Extension Methods ////////////////
+
+// Should use `ComponentModel.extend` or `class XXXX extend ComponentModel` to create class.
+// Then use `registerComponentModel` in `install` parameter when `use` this extension. For example:
+// class Bar3DModel extends ComponentModel {}
+// export function install(registers) { regsiters.registerComponentModel(Bar3DModel); }
+// echarts.use(install);
+export function extendComponentModel(proto: object): ComponentModel {
+    const Model = (ComponentModel as ComponentModelConstructor).extend(proto) as any;
+    ComponentModel.registerClass(Model);
+    return Model;
+}
+
+export function extendComponentView(proto: object): ChartView {
+    const View = (ComponentView as ComponentViewConstructor).extend(proto) as any;
+    ComponentView.registerClass(View);
+    return View;
+}
+
+export function extendSeriesModel(proto: object): SeriesModel {
+    const Model = (SeriesModel as SeriesModelConstructor).extend(proto) as any;
+    SeriesModel.registerClass(Model);
+    return Model;
+}
+
+export function extendChartView(proto: object): ChartView {
+    const View = (ChartView as ChartViewConstructor).extend(proto) as any;
+    ChartView.registerClass(View);
+    return View;
+}

--- a/src/export/api/helper.ts
+++ b/src/export/api/helper.ts
@@ -36,6 +36,8 @@ import {
 import SeriesModel from '../../model/Series';
 import { AxisBaseModel } from '../../coord/AxisBaseModel';
 import { getECData } from '../../util/innerStore';
+import { createTextStyle as innerCreateTextStyle } from '../../label/labelStyle';
+import { TextCommonOption } from '../../util/types';
 
 /**
  * Create a muti dimension List structure from seriesModel.
@@ -113,3 +115,9 @@ export function mixinAxisModelCommonMethods(Model: Model) {
 }
 
 export {getECData};
+
+export {enableHoverEmphasis} from '../../util/states';
+
+export function createTextStyle(textStyleModel: Model<TextCommonOption>) {
+    return innerCreateTextStyle(textStyleModel);
+}

--- a/src/export/api/helper.ts
+++ b/src/export/api/helper.ts
@@ -37,7 +37,7 @@ import SeriesModel from '../../model/Series';
 import { AxisBaseModel } from '../../coord/AxisBaseModel';
 import { getECData } from '../../util/innerStore';
 import { createTextStyle as innerCreateTextStyle } from '../../label/labelStyle';
-import { TextCommonOption } from '../../util/types';
+import { DisplayState, TextCommonOption } from '../../util/types';
 
 /**
  * Create a muti dimension List structure from seriesModel.
@@ -118,6 +118,13 @@ export {getECData};
 
 export {enableHoverEmphasis} from '../../util/states';
 
-export function createTextStyle(textStyleModel: Model<TextCommonOption>) {
-    return innerCreateTextStyle(textStyleModel);
+export function createTextStyle(
+    textStyleModel: Model<TextCommonOption>,
+    opts?: {
+        // For which state this textStyle is for.
+        state?: DisplayState
+    }
+) {
+    opts = opts || {};
+    return innerCreateTextStyle(textStyleModel, null, null, opts.state !== 'normal');
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,11 @@ const extensionRegisters = {
     registerLoading,
     registerMap,
     PRIORITY,
+
+    ComponentModel,
+    ComponentView,
+    SeriesModel,
+    ChartView,
     // TODO Use ComponentModel and SeriesModel instead of Constructor
     registerComponentModel(ComponentModelClass: Constructor) {
         ComponentModel.registerClass(ComponentModelClass);

--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -306,7 +306,8 @@ export function createTextStyle(
     textStyleModel: Model,
     specifiedTextStyle?: TextStyleProps, // Fixed style in the code. Can't be set by model.
     opt?: Pick<TextCommonParams, 'inheritColor' | 'disableBox'>,
-    isNotNormal?: boolean, isAttached?: boolean // If text is attached on an element. If so, auto color will handling in zrender.
+    isNotNormal?: boolean,
+    isAttached?: boolean // If text is attached on an element. If so, auto color will handling in zrender.
 ) {
     const textStyle: TextStyleProps = {};
     setTextStyleCommon(textStyle, textStyleModel, opt, isNotNormal, isAttached);

--- a/src/model/Component.ts
+++ b/src/model/Component.ts
@@ -336,7 +336,7 @@ export type ComponentModelConstructor = typeof ComponentModel
     & componentUtil.TopologicalTravelable<object>;
 
 mountExtend(ComponentModel, Model);
-enableClassManagement(ComponentModel as ComponentModelConstructor, {registerWhenExtend: true});
+enableClassManagement(ComponentModel as ComponentModelConstructor);
 componentUtil.enableSubTypeDefaulter(ComponentModel as ComponentModelConstructor);
 componentUtil.enableTopologicalTravel(ComponentModel as ComponentModelConstructor, getDependencies);
 

--- a/src/scale/Scale.ts
+++ b/src/scale/Scale.ts
@@ -181,8 +181,6 @@ abstract class Scale<SETTING extends Dictionary<unknown> = Dictionary<unknown>> 
 }
 
 type ScaleConstructor = typeof Scale & clazzUtil.ClassManager;
-clazzUtil.enableClassManagement(Scale as ScaleConstructor, {
-    registerWhenExtend: true
-});
+clazzUtil.enableClassManagement(Scale as ScaleConstructor);
 
 export default Scale;

--- a/src/util/clazz.ts
+++ b/src/util/clazz.ts
@@ -228,11 +228,8 @@ export interface ClassManager {
  * ```
  */
 export function enableClassManagement(
-    target: ClassManager,
-    options?: {registerWhenExtend?: boolean}
+    target: ClassManager
 ): void {
-
-    options = options || {};
 
     /**
      * Component model classes
@@ -353,17 +350,6 @@ export function enableClassManagement(
             container[IS_CONTAINER] = true;
         }
         return container as SubclassContainer;
-    }
-
-    // FIXME:TS remove `registerWhenExtend` finally when ts migration completed?
-    if (options.registerWhenExtend) {
-        const originalExtend = (target as any).extend;
-        if (originalExtend) {
-            (target as any).extend = function (proto: any) {
-                const ExtendedClass = originalExtend.call(this, proto);
-                return target.registerClass(ExtendedClass);
-            };
-        }
     }
 }
 

--- a/src/view/Chart.ts
+++ b/src/view/Chart.ts
@@ -230,7 +230,7 @@ export type ChartViewConstructor = typeof ChartView
     & clazzUtil.ClassManager;
 
 clazzUtil.enableClassExtend(ChartView as ChartViewConstructor, ['dispose']);
-clazzUtil.enableClassManagement(ChartView as ChartViewConstructor, {registerWhenExtend: true});
+clazzUtil.enableClassManagement(ChartView as ChartViewConstructor);
 
 
 function renderTaskPlan(context: SeriesTaskContext): StageHandlerPlanReturn {

--- a/src/view/Component.ts
+++ b/src/view/Component.ts
@@ -107,6 +107,6 @@ export type ComponentViewConstructor = typeof ComponentView
     & clazzUtil.ClassManager;
 
 clazzUtil.enableClassExtend(ComponentView as ComponentViewConstructor);
-clazzUtil.enableClassManagement(ComponentView as ComponentViewConstructor, {registerWhenExtend: true});
+clazzUtil.enableClassManagement(ComponentView as ComponentViewConstructor);
 
 export default ComponentView;


### PR DESCRIPTION
## Major changes:

### 1. Expose non-self-register extend API for extensions.

So extensions like ECharts GL which provide multiple charts and components can also have the new minimal import API.

An example:
```js
// In extension code.
class Scatter3DChartView extends echarts.ChartView {
  ....
}
class Scatter3DSeriesModel extends echarts.SeriesModel {
  ....
}

export function Scatter3DChart(registers) {
  registers.registerChartView(FooChartView);
}

// In users code
import {use} from 'echarts/core/';
import {Scatter3DChart} from 'echarts-gl/charts';
use([Scatter3DChart]);
```

### 2. Expose several helper methods for extension usage.

+  `echarts.helper.createTextStyle`
+  `echarts.helper.enableHoverEmphasis` 

### 3. Mark as sideEffects in extensions.