### PR TITLE
Fix unexpected global name usage

### DIFF
--- a/.eslintrc-common.yaml
+++ b/.eslintrc-common.yaml
@@ -216,4 +216,14 @@ rules:
         -
             vars: "local"
             args: "none"
-    "@typescript-eslint/no-redeclare": 2
+    # Avoid dangerous usage of globals.
+    "no-restricted-globals":
+        - 2
+        - "event"
+        - "name"
+        - "length"
+        - "orientation"
+        - "top"
+        - "parent"
+        - "location"
+        - "closed"

--- a/src/.eslintrc.yaml
+++ b/src/.eslintrc.yaml
@@ -37,11 +37,12 @@ parserOptions:
     project: "tsconfig.json"
 plugins: ["@typescript-eslint"]
 env:
-    browser: true
-    node: true
     es6: false
 globals:
     jQuery: false
     Promise: false
+    console: true
+    setTimeout: true
+    clearTimeout: true
     __DEV__: true
 extends: '../.eslintrc-common.yaml'

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -107,6 +107,7 @@ import CanvasPainter from 'zrender/src/canvas/Painter';
 import SVGPainter from 'zrender/src/svg/Painter';
 
 declare let global: any;
+
 type ModelFinder = modelUtil.ModelFinder;
 
 const assert = zrUtil.assert;
@@ -114,6 +115,8 @@ const each = zrUtil.each;
 const isFunction = zrUtil.isFunction;
 const isObject = zrUtil.isObject;
 const indexOf = zrUtil.indexOf;
+
+const hasWindow = typeof window !== 'undefined';
 
 export const version = '5.0.0';
 
@@ -377,13 +380,14 @@ class ECharts extends Eventful {
 
         this._dom = dom;
 
-        const root = (
-            typeof window === 'undefined' ? global : window
-        ) as any;
-
         let defaultRenderer = 'canvas';
         let defaultUseDirtyRect = false;
         if (__DEV__) {
+            const root = (
+                /* eslint-disable-next-line */
+                hasWindow ? window : global
+            ) as any;
+
             defaultRenderer = root.__ECHARTS__DEFAULT__RENDERER__ || defaultRenderer;
 
             const devUseDirtyRect = root.__ECHARTS__DEFAULT__USE_DIRTY_RECT__;
@@ -633,7 +637,9 @@ class ECharts extends Eventful {
     }
 
     getDevicePixelRatio(): number {
-        return (this._zr.painter as CanvasPainter).dpr || window.devicePixelRatio || 1;
+        return (this._zr.painter as CanvasPainter).dpr
+            /* eslint-disable-next-line */
+            || (hasWindow && window.devicePixelRatio) || 1;
     }
 
     /**

--- a/src/core/locale.ts
+++ b/src/core/locale.ts
@@ -36,6 +36,7 @@ const localeModels: Dictionary<Model> = {};
 
 export const SYSTEM_LANG = !env.domSupported ? DEFAULT_LOCALE : (function () {
     const langStr = (
+        /* eslint-disable-next-line */
         document.documentElement.lang || navigator.language || (navigator as any).browserLanguage
     ).toUpperCase();
     return langStr.indexOf(LOCALE_ZH) > -1 ? LOCALE_ZH : DEFAULT_LOCALE;

--- a/src/data/Source.ts
+++ b/src/data/Source.ts
@@ -471,7 +471,7 @@ function normalizeDimensionsOption(dimensionsDefine: DimensionDefinitionLoose[])
         // User can set null in dimensions.
         // We dont auto specify name, othewise a given name may
         // cause it be refered unexpectedly.
-        if (name == null) {
+        if (item.name == null) {
             return item;
         }
 

--- a/src/model/globalDefault.ts
+++ b/src/model/globalDefault.ts
@@ -21,6 +21,7 @@
 let platform = '';
 // Navigator not exists in node
 if (typeof navigator !== 'undefined') {
+    /* global navigator */
     platform = navigator.platform || '';
 }
 

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -334,6 +334,7 @@ export {truncateText} from 'zrender/src/graphic/helper/parseText';
  * @param target blank or self
  */
 export function windowOpen(link: string, target: string): void {
+    /* global window */
     if (target === '_blank' || target === 'blank') {
         const blank = window.open();
         blank.opener = null;


### PR DESCRIPTION
Major changes

1. Avoid unexpected usage of `name`. Fix #13983
2. Remove `node`, `browser` env to avoid unexpected usage of global variables, even like `window`. Which may lead to compatible issues in specific environements