### PR TITLE
Fix(tooltip): 'findEventDispatcher' should add  'returnFirstMatch'  f…

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -576,7 +576,7 @@ class TooltipView extends ComponentView {
         el: ECElement,
         dispatchAction: ExtensionAPI['dispatchAction']
     ) {
-        const dispatcher = findEventDispatcher(el, (target) => getECData(target).dataIndex != null);
+        const dispatcher = findEventDispatcher(el, (target) => getECData(target).dataIndex != null, true);
         const ecModel = this._ecModel;
         const ecData = getECData(dispatcher);
         // Use dataModel in element if possible

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -429,7 +429,7 @@ class TooltipView extends ComponentView {
             this._showAxisTooltip(dataByCoordSys, e);
         }
         // Always show item tooltip if mouse is on the element with dataIndex
-        else if (el && findEventDispatcher(el, (target) => getECData(target).dataIndex != null)) {
+        else if (el && findEventDispatcher(el, (target) => getECData(target).dataIndex != null), true) {
             this._lastDataByCoordSys = null;
             this._showSeriesItemTooltip(e, el, dispatchAction);
         }


### PR DESCRIPTION
…or tooltip

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Add  `returnFirstMatch` for `tooltip`



### Fixed issues

Close #13971


## Details

### Before: What was the problem?


![Screen Shot 2021-01-08 at 16 54 29](https://user-images.githubusercontent.com/20318608/103994618-35a63880-51d2-11eb-8bec-7b95742da415.png)


### After: How is it fixed in this PR?

![Screen Shot 2021-01-08 at 16 54 00](https://user-images.githubusercontent.com/20318608/103994638-3ccd4680-51d2-11eb-9ff5-9bf2f4714d30.png)




## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
