### PR TITLE
fix: when mouse on blank area tooltip throw error

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -429,7 +429,7 @@ class TooltipView extends ComponentView {
             this._showAxisTooltip(dataByCoordSys, e);
         }
         // Always show item tooltip if mouse is on the element with dataIndex
-        else if (el && findEventDispatcher(el, (target) => getECData(target).dataIndex != null), true) {
+        else if (el && findEventDispatcher(el, (target) => getECData(target).dataIndex != null, true)) {
             this._lastDataByCoordSys = null;
             this._showSeriesItemTooltip(e, el, dispatchAction);
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?
fix `TooltipView.ts` bug

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

- #13996
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
when the mouse moves to show the tooltip will throw an error, because in the file `src/component/tooltip/TooltipView.ts`, Line 432 `else if` statement always `true`, although`el` value is undefined.
```javascript
 else if (el && findEventDispatcher(el, (target) => getECData(target).dataIndex != null), true) {
```
<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

![image](https://user-images.githubusercontent.com/11540271/104104171-6759f500-52e1-11eb-8048-c77223834c6a.png)
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?
give the correct parameters.
<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

[test/toolbox-tooltip](https://github.com/fajiaopaopao/incubator-echarts/blob/master/test/toolbox-tooltip.html)



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
