### PR TITLE
fix(toolbox): use current device pixel ratio by default for exporting crisp and clear images.

### DIFF
--- a/src/component/toolbox/feature/SaveAsImage.ts
+++ b/src/component/toolbox/feature/SaveAsImage.ts
@@ -44,7 +44,6 @@ export interface ToolboxSaveAsImageFeatureOption extends ToolboxFeatureOption {
 class SaveAsImage extends ToolboxFeature<ToolboxSaveAsImageFeatureOption> {
 
     onclick(ecModel: GlobalModel, api: ExtensionAPI) {
-
         const model = this.model;
         const title = model.get('name') || ecModel.get('title.0.text') || 'echarts';
         const isSvg = api.getZr().painter.getType() === 'svg';
@@ -133,7 +132,8 @@ class SaveAsImage extends ToolboxFeature<ToolboxSaveAsImageFeatureOption> {
             connectedBackgroundColor: '#fff',
             name: '',
             excludeComponents: ['toolbox'],
-            pixelRatio: 1,
+            // use current pixel ratio of device by default
+            // pixelRatio: 1,
             lang: ecModel.getLocale(['toolbox', 'saveAsImage', 'lang'])
         };
 

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -653,7 +653,7 @@ class ECharts extends Eventful {
             return;
         }
         opts = zrUtil.extend({}, opts || {});
-        opts.pixelRatio = opts.pixelRatio || 1;
+        opts.pixelRatio = opts.pixelRatio || this.getDevicePixelRatio();
         opts.backgroundColor = opts.backgroundColor
             || this._model.get('backgroundColor');
         const zr = this._zr;
@@ -755,7 +755,7 @@ class ECharts extends Eventful {
             let right = -MAX_NUMBER;
             let bottom = -MAX_NUMBER;
             const canvasList: {dom: HTMLCanvasElement | string, left: number, top: number}[] = [];
-            const dpr = (opts && opts.pixelRatio) || 1;
+            const dpr = (opts && opts.pixelRatio) || this.getDevicePixelRatio();
 
             zrUtil.each(instances, function (chart, id) {
                 if (chart.group === groupId) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Currently, we are using the default value `1` as the DPR instead of the real device pixel ratio of the user, which will make the exported image blurred in retina devices. To get a clear one, the user has to set the option as follows:
```js
toolbox: {
    feature: {
        saveAsImage: {
            pixelRatio: 2.5 // specific dpr
        }
    }
}
```
This PR is intended to enable users to export a clearer image without any specific option.

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
By default, the exported image is blurred in retina devices.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![blurred](https://user-images.githubusercontent.com/26999792/104141639-c22f4180-53f2-11eb-8bac-ad508006d751.png)

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Don't specify the default `pixelRatio` as `1`. Use the `ECharts#getDevicePixelRatio()` method to get the real dpr instead.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![crisp](https://user-images.githubusercontent.com/26999792/104141644-c78c8c00-53f2-11eb-8c19-4ff224573013.png)


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

Please refer to `test/toolbox-title.html` or any other case related to the toolbox.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
