### PR TITLE
fix(data): fix wrong data fetch when appendData with TypedArray

### DIFF
--- a/src/data/helper/dataProvider.ts
+++ b/src/data/helper/dataProvider.ts
@@ -201,7 +201,8 @@ export class DefaultDataProvider implements DataProvider {
                 const count = end - start;
                 const arr = storage[dim];
                 for (let i = 0; i < count; i++) {
-                    const val = data[(start + i) * dimSize + dim];
+                    // appendData with TypedArray will always do replace in provider.
+                    const val = data[i * dimSize + dim];
                     arr[start + i] = val;
                     val < min && (min = val);
                     val > max && (max = val);


### PR DESCRIPTION
In dataProvider, when `appendData` with TypedArray source. It will always do a replacement. So we should not add a `start` offset when filling the `List#_storage`  from dataProvider.

It will fix the issue of `scatterGL-gps` example.